### PR TITLE
Presentation XML caption refactor: restore linking to only be from mo…

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,1 @@
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "feature/presxml-autonum"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,1 +1,3 @@
 gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "feature/presxml-autonum"
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "fix/markup-connectives"
+

--- a/lib/metanorma/default/cleanup.rb
+++ b/lib/metanorma/default/cleanup.rb
@@ -112,7 +112,7 @@ module Metanorma
       def unwrap_para(ddef)
         e = ddef.elements and e.size == 1 && e.first.name == "p" and
           ddef = e.first
-        ddef.children.to_xml
+        to_xml(ddef.children)
       end
 
       def reqt_dl_to_classif(ins, reqt, dlist)

--- a/lib/metanorma/default/isodoc.rb
+++ b/lib/metanorma/default/isodoc.rb
@@ -6,13 +6,16 @@ module Metanorma
       end
 
       def recommendation_label(elem, type, xrefs)
-        number = xrefs.anchor(elem["id"], :label, false)
-        (number.nil? ? type : "#{type} #{number}")
+        num = xrefs.anchor(elem["id"], :label, false)
+        type = "<span class='fmt-element-name'>#{type}</span>"
+        num.nil? and return type
+        num = "<semx element='autonum' source='#{elem['id']}'>#{num}</semx>"
+        "#{type} #{num}"
       end
 
       def reqt_metadata_node?(node)
         %w(identifier title subject classification tag value
-           inherit name).include? node.name
+           inherit name fmt-name fmt-xref-label fmt-title).include? node.name
       end
 
       def requirement_render1(node)
@@ -35,7 +38,7 @@ module Metanorma
 
       def recommendation_labels(node)
         [node.at(ns("./identifier")), node.at(ns("./title")),
-         node.at(ns("./name"))]
+         node.at(ns("./fmt-name"))]
           .map do |n|
           n&.children&.to_xml
         end
@@ -50,7 +53,7 @@ module Metanorma
           ret << ". " if label && title
           ret << title
         end
-        out << "<name>#{l10n(ret.compact.join)}</name>"
+        out << "<fmt-name>#{l10n(ret.compact.join)}</fmt-name>"
         out
       end
 

--- a/lib/metanorma/default/isodoc.rb
+++ b/lib/metanorma/default/isodoc.rb
@@ -6,11 +6,28 @@ module Metanorma
       end
 
       def recommendation_label(elem, type, xrefs)
-        num = xrefs.anchor(elem["id"], :label, false)
+        label, title = recommendation_labels(elem)
         type = "<span class='fmt-element-name'>#{type}</span>"
-        num.nil? and return type
-        num = "<semx element='autonum' source='#{elem['id']}'>#{num}</semx>"
-        "#{type} #{num}"
+        num = xrefs.anchor(elem["id"], :label, false)
+        num &&= "<semx element='autonum' source='#{elem['id']}'>#{num}</semx>"
+        ret = "#{type} #{num}".strip
+        label || title and
+          ret += recommendation_label_add(elem, label, title)
+        ret
+      end
+
+      def recommendation_label_add(elem, label, title)
+        r = recommendation_label_caption_delim
+        label and
+          r += "<semx element='identifier' source='#{elem['id']}'>#{label}</semx>"
+        label && title and r += ". "
+        title and
+          r += "<semx element='title' source='#{elem['id']}'>#{title}</semx>"
+        r
+      end
+
+      def recommendation_label_caption_delim
+        "<span class='fmt-caption-delim'>:<br/></span>"
       end
 
       def reqt_metadata_node?(node)
@@ -28,33 +45,25 @@ module Metanorma
         out
       end
 
+      def recommendation_header(_node, out)
+        out
+      end
+
       def recommendation_base(node, klass)
         out = node.document.create_element(klass)
         node.attributes.each do |k, v|
           out[k] = v
         end
+        n = node.at(ns("./fmt-name")) and out << n
+        n = node.at(ns("./fmt-xref-label")) and out << n
         out
       end
 
       def recommendation_labels(node)
-        [node.at(ns("./identifier")), node.at(ns("./title")),
-         node.at(ns("./fmt-name"))]
+        [node.at(ns("./identifier")), node.at(ns("./title"))]
           .map do |n|
           n&.children&.to_xml
         end
-      end
-
-      def recommendation_header(node, out)
-        label, title, name = recommendation_labels(node)
-        ret = name ? [name] : []
-        if label || title
-          ret << ":" unless ret.empty?
-          ret += ["<br/>", label]
-          ret << ". " if label && title
-          ret << title
-        end
-        out << "<fmt-name>#{l10n(ret.compact.join)}</fmt-name>"
-        out
       end
 
       def recommendation_attributes1(node, out)

--- a/lib/metanorma/default/isodoc.rb
+++ b/lib/metanorma/default/isodoc.rb
@@ -62,7 +62,7 @@ module Metanorma
       def recommendation_labels(node)
         [node.at(ns("./identifier")), node.at(ns("./title"))]
           .map do |n|
-          n&.children&.to_xml
+          to_xml(n&.children)
         end
       end
 
@@ -82,14 +82,14 @@ module Metanorma
       end
 
       def recommendation_attr_parse(node, label)
-        l10n("#{label}: #{node.children.to_xml}")
+        l10n("#{label}: #{to_xml(node.children)}")
       end
 
       def recommendation_attr_keyvalue(node, key, value)
         tag = node.at(ns("./#{key}")) or return nil
         value = node.at(ns("./#{value}")) or return nil
         l10n("#{Metanorma::Utils.strict_capitalize_first tag.text}: " \
-             "#{value.children.to_xml}")
+             "#{to_xml(value.children)}")
       end
 
       def recommendation_attributes(node, out)

--- a/lib/metanorma/default/utils.rb
+++ b/lib/metanorma/default/utils.rb
@@ -22,6 +22,11 @@ module Metanorma
       def ns(xpath)
         Metanorma::Utils.ns(xpath)
       end
+
+      def to_xml(node)
+        node&.to_xml(encoding: "UTF-8", indent: 0,
+                   save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
+      end
     end
   end
 end

--- a/lib/metanorma/modspec/cleanup.rb
+++ b/lib/metanorma/modspec/cleanup.rb
@@ -127,7 +127,7 @@ module Metanorma
           next if %w(p ol ul dl table component description)
             .include?(c&.elements&.first&.name)
 
-          c.children = "<p>#{c.children.to_xml}</p>"
+          c.children = "<p>#{to_xml(c.children)}</p>"
         end
       end
 

--- a/lib/metanorma/modspec/isodoc.rb
+++ b/lib/metanorma/modspec/isodoc.rb
@@ -49,8 +49,8 @@ module Metanorma
 
       def recommendation_name(node, _out)
         ret = ""
-        name = node.at(ns("./name")) and ret += name.children.to_xml
-        title = node.at(ns("./title"))
+        name = node.at(ns("./fmt-name")) and ret += name.children.to_xml
+        title = node.at(ns("./fmt-title"))
         return ret unless title &&
           node.ancestors("requirement, recommendation, permission").empty?
 

--- a/lib/metanorma/modspec/isodoc.rb
+++ b/lib/metanorma/modspec/isodoc.rb
@@ -92,7 +92,7 @@ module Metanorma
         label = node.at(ns("./identifier")) or return
         ret = <<~OUTPUT
           <tr><th>#{@labels['modspec']['identifier']}</th>
-          <td><tt><modspec-ident>#{label.children.to_xml}</modspec-ident></tt></td>
+          <td><tt><modspec-ident>#{to_xml(label.children)}</modspec-ident></tt></td>
         OUTPUT
         out.add_child(ret)
       end
@@ -140,7 +140,7 @@ module Metanorma
       def recommendation_attributes1_inherit(node, head)
         node.xpath(ns("./inherit")).each do |i|
           head << [@labels["modspec"]["dependency"],
-                   recommendation_id(i.children.to_xml)]
+                   recommendation_id(to_xml(i.children))]
         end
         head
       end
@@ -149,7 +149,7 @@ module Metanorma
         %w(indirect-dependency implements).each do |x|
           node.xpath(ns("./classification[tag][value]")).each do |c|
             c.at(ns("./tag")).text.casecmp(x).zero? or next
-            xref = recommendation_id(c.at(ns("./value")).children.to_xml) and
+            xref = recommendation_id(to_xml(c.at(ns("./value")).children)) and
               head << [@labels["modspec"][x.delete("-")], xref]
           end
         end
@@ -166,9 +166,9 @@ module Metanorma
 
         d = node.at(ns("./component[@class = 'step']"))
         d = d.replace("<ol class='steps'><li#{id_attr(d)}>" \
-                      "#{d.children.to_xml}</li></ol>").first
+                      "#{to_xml(d.children)}</li></ol>").first
         node.xpath(ns("./component[@class = 'step']")).each do |f|
-          f = f.replace("<li#{id_attr(f)}>#{f.children.to_xml}</li>").first
+          f = f.replace("<li#{id_attr(f)}>#{to_xml(f.children)}</li>").first
           d << f
         end
         node
@@ -223,7 +223,7 @@ module Metanorma
         recommend_class(node.parent) == "recommend" and
           lbl = "statement"
         out << "<tr><th>#{@labels['modspec'][lbl]}</th>" \
-               "<td>#{node.children.to_xml}</td></tr>"
+               "<td>#{to_xml(node.children)}</td></tr>"
         out
       end
 
@@ -240,8 +240,8 @@ module Metanorma
         node.xpath(ns("./dt")).each do |dt|
           dd = dt.next_element
           dd&.name == "dd" or next
-          out.add_child("<tr><th>#{dt.children.to_xml}</th>" \
-                        "<td>#{dd.children.to_xml}</td></tr>")
+          out.add_child("<tr><th>#{to_xml(dt.children)}</th>" \
+                        "<td>#{to_xml(dd.children)}</td></tr>")
         end
         out
       end

--- a/lib/metanorma/modspec/isodoc.rb
+++ b/lib/metanorma/modspec/isodoc.rb
@@ -34,7 +34,7 @@ module Metanorma
       end
 
       def recommendation_header(reqt, out)
-        n = recommendation_name(reqt, nil)
+        n = reqt.at(ns("./fmt-name"))
         x = if reqt.ancestors("requirement, recommendation, permission").empty?
               <<~THEAD
                 <thead><tr><th scope='colgroup' colspan='2'><p class='#{recommend_name_class(reqt)}'>#{n}</p></th></tr></thead>
@@ -47,6 +47,7 @@ module Metanorma
         out
       end
 
+=begin
       def recommendation_name(node, _out)
         ret = ""
         name = node.at(ns("./fmt-name")) and ret += name.children.to_xml
@@ -57,6 +58,25 @@ module Metanorma
         ret += ": " unless !name || name.text.empty?
         ret += title.children.to_xml
         l10n(ret)
+      end
+=end
+
+      def recommendation_label_add(elem, _label, title)
+        title or return ""
+        r = recommendation_label_caption_delim
+        title and
+          r += "<semx element='title' source='#{elem['id']}'>#{title}</semx>"
+        r
+      end
+
+      def recommendation_label_caption_delim
+        "<span class='fmt-caption-delim'>: </span>"
+      end
+
+      def recommendation_labels(node)
+        node.ancestors("requirement, recommendation, permission").empty? or
+          return [nil, nil]
+        super
       end
 
       def recommendation_attributes(node, out)

--- a/lib/metanorma/modspec/reqt_label.rb
+++ b/lib/metanorma/modspec/reqt_label.rb
@@ -27,10 +27,11 @@ module Metanorma
       def recommendation_label_xref(elem, label, xrefs, type)
         id = @reqtlabels[label]
         number = xrefs.anchor(id, :modspec, false)
-        number.nil? and return type
+        number.nil? and return "<span class='fmt-element-name'>#{type}</span>"
         elem.ancestors("requirement, recommendation, permission").empty? and
           return number
-        "<xref target='#{id}'>#{number}</xref>"
+        #"<xref target='#{id}'>#{number}</xref>"
+        number
       end
 
       def init_lookups(doc)
@@ -103,7 +104,8 @@ module Metanorma
 
       def recommendation_link_test(ident)
         test = @reqt_links_test[ident&.strip] or return nil
-        "<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        #"<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        test[:lbl]
       end
 
       # we have not implemented multiple levels of nesting of classes
@@ -155,12 +157,15 @@ module Metanorma
 
       def recommendation_link_class(ident)
         test = @reqt_links_class[ident&.strip] or return nil
-        "<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        #"<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        test[:lbl]
       end
 
       def recommendation_id(ident)
         test = @reqt_ids[ident&.strip] or return ident&.strip
-        "<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        #require "debug"; binding.b if test.include?("<xref")
+        #"<xref target='#{test[:id]}'>#{test[:lbl]}</xref>"
+        test[:lbl]
       end
 
       def recommendation_backlinks_test(node, id, ret)

--- a/lib/metanorma/modspec/reqt_label.rb
+++ b/lib/metanorma/modspec/reqt_label.rb
@@ -190,7 +190,7 @@ module Metanorma
           .xpath(ns("//requirement//xref | //permission//xref | " \
                     "//recommendation//xref"))).each do |x|
           @reqt_id_base[x["target"]] or next # is a modspec requirement
-          x.children = x.children.to_xml.delete_prefix(@modspecidentifierbase)
+          x.children = to_xml(x.children).delete_prefix(@modspecidentifierbase)
         end
       end
 

--- a/lib/metanorma/modspec/table_cleanup.rb
+++ b/lib/metanorma/modspec/table_cleanup.rb
@@ -96,7 +96,7 @@ module Metanorma
       # any xrefs not yet expanded out to rendering need to be expanded out,
       # so that the identifier instances they contain can be truncated
       def expand_xrefs_in_reqt(table)
-        table.xpath(ns(".//xref[not(@style)][normalize-space(text()) = '']"))
+        table.xpath(ns(".//xref[not(@style)][string-length() = 0]"))
           .each do |x|
           ref = @xrefs.anchor(x["target"], :xref, false) or next
           x << ref

--- a/lib/metanorma/modspec/table_cleanup.rb
+++ b/lib/metanorma/modspec/table_cleanup.rb
@@ -65,6 +65,8 @@ module Metanorma
           x = t.at(ns("./thead/tr")) or next
           x.at(ns("./th")).children =
             requirement_table_nested_cleanup_hdr(node)
+          f = x.at(ns("./td/fmt-name")) and
+            f.replace(f.children)
           t.parent.parent.replace(x)
         end
         table

--- a/lib/metanorma/modspec/table_cleanup.rb
+++ b/lib/metanorma/modspec/table_cleanup.rb
@@ -46,7 +46,7 @@ module Metanorma
         hdr = th.text
         th.children = @i18n.inflect(hdr, number: "pl")
         td = th.next_element
-        res = [td.children.to_xml]
+        res = [to_xml(td.children)]
         res += gather_consec_table_rows(trow, hdr)
         td.children = res.join("<br/>")
       end
@@ -55,7 +55,7 @@ module Metanorma
         ret = []
         trow.xpath("./following-sibling::xmlns:tr").each do |r|
           r.at(ns("./th[text() = '#{hdr}']")) or break
-          ret << r.remove.at(ns("./td")).children.to_xml
+          ret << to_xml(r.remove.at(ns("./td")).children)
         end
         ret
       end
@@ -80,7 +80,7 @@ module Metanorma
 
       def strip_id_base(elem, base)
         base.nil? and return elem.children
-        elem.children.to_xml.delete_prefix(base)
+        to_xml(elem.children).delete_prefix(base)
       end
 
       def truncate_id_base_in_reqt1(table, base)

--- a/spec/default/render_spec.rb
+++ b/spec/default/render_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Metanorma::Requirements::Default do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">
           <preface><foreword>
-          <permission id="_"   keep-with-next="true" keep-lines-together="true" model="default">
+          <permission id="A"   keep-with-next="true" keep-lines-together="true" model="default">
         <identifier>/ogc/recommendation/wfs/2</identifier>
         <inherit>/ss/584/2015/level/1</inherit>
         <inherit><eref type="inline" bibitemid="rfc2616" citeas="RFC 2616">RFC 2616 (HTTP/1.1)</eref></inherit>
@@ -37,7 +37,7 @@ RSpec.describe Metanorma::Requirements::Default do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -64,49 +64,112 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     presxml = <<~OUTPUT
-          <foreword displayorder="2">
-          <title>Foreword</title>
-          <permission id="_" keep-with-next="true" keep-lines-together="true" model="default"><name>Permission 1:<br/>/ogc/recommendation/wfs/2</name><p><em>Subject: user</em><br/>
-      <em>Subject: non-user</em><br/>
-      <em>Inherits: /ss/584/2015/level/1</em><br/>
-      <em>Inherits: <xref type="inline" target="rfc2616">RFC 2616 (HTTP/1.1)</xref></em><br/>
-      <em>Control-class: Technical</em><br/>
-      <em>Priority: P0</em><br/>
-      <em>Family: System and Communications Protection</em><br/>
-      <em>Family: System and Communications Protocols</em></p><div type="requirement-description">
-          <p id="_">I recommend <em>this</em>.</p>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <permission id="A" keep-with-next="true" keep-lines-together="true" model="default" autonum="1">
+             <fmt-name>
+                <span class="fmt-caption-label">
+                   <span class="fmt-element-name">Permission</span>
+                   <semx element="autonum" source="A">1</semx>
+                </span>
+                :
+                <br/>
+                /ogc/recommendation/wfs/2
+             </fmt-name>
+             <p>
+                <em>Subject: user</em>
+                <br/>
+                <em>Subject: non-user</em>
+                <br/>
+                <em>Inherits: /ss/584/2015/level/1</em>
+                <br/>
+                <em>
+                   Inherits:
+                   <xref type="inline" target="rfc2616">RFC 2616 (HTTP/1.1)</xref>
+                </em>
+                <br/>
+                <em>Control-class: Technical</em>
+                <br/>
+                <em>Priority: P0</em>
+                <br/>
+                <em>Family: System and Communications Protection</em>
+                <br/>
+                <em>Family: System and Communications Protocols</em>
+             </p>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="A">1</semx>
+             </fmt-xref-label>
+             <div type="requirement-description">
+                <p id="_">
+                   I recommend
+                   <em>this</em>
+                   .
+                </p>
                 <dl>
-        <dt>scope</dt>
-        <dd>random</dd>
-        <dt>widgets</dt>
-        <dd>randomer</dd>
-      </dl>
-        </div>
-        <note id="N"><name>NOTE</name>This is a note</note>
-        <div type="requirement-description">
-          <p id="_">As for the measurement targets,</p>
-        </div><div exclude="false" type="requirement-measurement-target">
-          <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_"><name>(1)</name>
-            <stem type="AsciiMath">r/1 = 0</stem>
-          </formula>
-        </div><div exclude="false" type="requirement-verification">
-          <p id="_">The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
-            if (success)
-            recommendation(label: success-response)
-            end
-          </sourcecode>
-        </div><div exclude="false" class="component1" type="requirement-component1">
-                  <p id="_">Hello</p>
-                </div></permission>
-          </foreword>
+                   <dt>scope</dt>
+                   <dd>random</dd>
+                   <dt>widgets</dt>
+                   <dd>randomer</dd>
+                </dl>
+             </div>
+             <note id="N" autonum="">
+                <fmt-name>
+                   <span class="fmt-caption-label">
+                      <span class="fmt-element-name">NOTE</span>
+                   </span>
+                </fmt-name>
+                <fmt-xref-label>
+                   <span class="fmt-element-name">Note</span>
+                </fmt-xref-label>
+                This is a note
+             </note>
+             <div type="requirement-description">
+                <p id="_">As for the measurement targets,</p>
+             </div>
+             <div exclude="false" type="requirement-measurement-target">
+                <p id="_">The measurement target shall be measured as:</p>
+                <formula id="B" autonum="1">
+                   <fmt-name>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-autonum-delim">(</span>
+                         1
+                         <span class="fmt-autonum-delim">)</span>
+                      </span>
+                   </fmt-name>
+                   <fmt-xref-label>
+                      <span class="fmt-element-name">Formula</span>
+                      <span class="fmt-autonum-delim">(</span>
+                      <semx element="autonum" source="B">1</semx>
+                      <span class="fmt-autonum-delim">)</span>
+                   </fmt-xref-label>
+                   <stem type="AsciiMath">r/1 = 0</stem>
+                </formula>
+             </div>
+             <div exclude="false" type="requirement-verification">
+                <p id="_">The following code will be run for verification:</p>
+                <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
+             if (success)
+             recommendation(label: success-response)
+             end
+           </sourcecode>
+             </div>
+             <div exclude="false" class="component1" type="requirement-component1">
+                <p id="_">Hello</p>
+             </div>
+          </permission>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -165,35 +228,79 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     presxml = <<~OUTPUT
-          <foreword displayorder="2">
-          <title>Foreword</title>
-          <requirement id="A" unnumbered="true" keep-with-next="true" keep-lines-together="true" model="default"><name>Requirement:<br/>/ogc/recommendation/wfs/2. A New Requirement</name><p><em>Subject: user</em><br/>
-      <em>Inherits: /ss/584/2015/level/1</em></p><div type="requirement-description">
-          <p id="_">I recommend <em>this</em>.</p>
-        </div><div type="requirement-description">
-          <p id="_">As for the measurement targets,</p>
-        </div><div exclude="false" keep-with-next="true" keep-lines-together="true" type="requirement-measurement-target">
-          <p id="_">The measurement target shall be measured as:</p>
-          <formula id="B"><name>(1)</name>
-            <stem type="AsciiMath">r/1 = 0</stem>
-          </formula>
-        </div><div exclude="false" type="requirement-verification">
-          <p id="_">The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
-            if (success)
-            recommendation(label: success-response)
-            end
-          </sourcecode>
-        </div><div exclude="false" class="component1" type="requirement-component1">
-                  <p id="_">Hello</p>
-                </div></requirement>
-          </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <requirement id="A" unnumbered="true" keep-with-next="true" keep-lines-together="true" model="default">
+             <fmt-name>
+                <span class="fmt-caption-label">
+                   <span class="fmt-element-name">Requirement</span>
+                </span>
+                :
+                <br/>
+                /ogc/recommendation/wfs/2. A New Requirement
+             </fmt-name>
+             <p>
+                <em>Subject: user</em>
+                <br/>
+                <em>Inherits: /ss/584/2015/level/1</em>
+             </p>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="A">(??)</semx>
+             </fmt-xref-label>
+             <div type="requirement-description">
+                <p id="_">
+                   I recommend
+                   <em>this</em>
+                   .
+                </p>
+             </div>
+             <div type="requirement-description">
+                <p id="_">As for the measurement targets,</p>
+             </div>
+             <div exclude="false" keep-with-next="true" keep-lines-together="true" type="requirement-measurement-target">
+                <p id="_">The measurement target shall be measured as:</p>
+                <formula id="B" autonum="1">
+                   <fmt-name>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-autonum-delim">(</span>
+                         1
+                         <span class="fmt-autonum-delim">)</span>
+                      </span>
+                   </fmt-name>
+                   <fmt-xref-label>
+                      <span class="fmt-element-name">Formula</span>
+                      <span class="fmt-autonum-delim">(</span>
+                      <semx element="autonum" source="B">1</semx>
+                      <span class="fmt-autonum-delim">)</span>
+                   </fmt-xref-label>
+                   <stem type="AsciiMath">r/1 = 0</stem>
+                </formula>
+             </div>
+             <div exclude="false" type="requirement-verification">
+                <p id="_">The following code will be run for verification:</p>
+                <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
+             if (success)
+             recommendation(label: success-response)
+             end
+           </sourcecode>
+             </div>
+             <div exclude="false" class="component1" type="requirement-component1">
+                <p id="_">Hello</p>
+             </div>
+          </requirement>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -204,7 +311,7 @@ RSpec.describe Metanorma::Requirements::Default do
           <language>fr</language>
           <script>Latn</script>
           </bibdata>
-          <preface><foreword>
+          <preface><foreword id="F">
           <requirement id="A" unnumbered="true" model="default">
         <title>A New Requirement</title>
         <identifier>/ogc/recommendation/wfs/2</identifier>
@@ -257,36 +364,80 @@ RSpec.describe Metanorma::Requirements::Default do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword displayorder="2">
-          <title>Avant-propos</title>
-          <requirement id="A" unnumbered="true" model="default"><name>Exigence&#xA0;:<br/>/ogc/recommendation/wfs/2. A New Requirement</name><p><em>Sujet&#xA0;: user</em><br/>
-      <em>H&#xE9;rite&#xA0;: /ss/584/2015/level/1</em></p><div type="requirement-description">
-          <p id="_">I recommend <em>this</em>.</p>
-        </div><div type="requirement-description">
-          <p id="_">As for the measurement targets,</p>
-        </div><div exclude="false" type="requirement-measurement-target">
-          <p id="_">The measurement target shall be measured as:</p>
-          <formula id="B"><name>(1)</name>
-            <stem type="AsciiMath">r/1 = 0</stem>
-          </formula>
-        </div><div exclude="false" type="requirement-verification">
-          <p id="_">The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
-        if (success)
-        recommendation(label: success-response)
-       end
-       </sourcecode>
-        </div><div exclude="false" class="component1" type="requirement-component1">
-                  <p id="_">Hello</p>
-                </div></requirement>
-          </foreword>
+      <foreword id="F" displayorder="2">
+          <title id="_">Avant-propos</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Avant-propos</semx>
+             </span>
+          </fmt-title>
+          <requirement id="A" unnumbered="true" model="default">
+             <fmt-name>
+                <span class="fmt-caption-label">
+                   <span class="fmt-element-name">Exigence</span>
+                </span>
+                :
+                <br/>
+                /ogc/recommendation/wfs/2. A New Requirement
+             </fmt-name>
+             <p>
+                <em>Sujet : user</em>
+                <br/>
+                <em>Hérite : /ss/584/2015/level/1</em>
+             </p>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="A">(??)</semx>
+             </fmt-xref-label>
+             <div type="requirement-description">
+                <p id="_">
+                   I recommend
+                   <em>this</em>
+                   .
+                </p>
+             </div>
+             <div type="requirement-description">
+                <p id="_">As for the measurement targets,</p>
+             </div>
+             <div exclude="false" type="requirement-measurement-target">
+                <p id="_">The measurement target shall be measured as:</p>
+                <formula id="B" autonum="1">
+                   <fmt-name>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-autonum-delim">(</span>
+                         1
+                         <span class="fmt-autonum-delim">)</span>
+                      </span>
+                   </fmt-name>
+                   <fmt-xref-label>
+                      <span class="fmt-element-name">Formule</span>
+                      <span class="fmt-autonum-delim">(</span>
+                      <semx element="autonum" source="B">1</semx>
+                      <span class="fmt-autonum-delim">)</span>
+                   </fmt-xref-label>
+                   <stem type="AsciiMath">r/1 = 0</stem>
+                </formula>
+             </div>
+             <div exclude="false" type="requirement-verification">
+                <p id="_">The following code will be run for verification:</p>
+                <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
+             if (success)
+             recommendation(label: success-response)
+             end
+           </sourcecode>
+             </div>
+             <div exclude="false" class="component1" type="requirement-component1">
+                <p id="_">Hello</p>
+             </div>
+          </requirement>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -294,7 +445,7 @@ RSpec.describe Metanorma::Requirements::Default do
     input = <<~INPUT
           <iso-standard xmlns="http://riboseinc.com/isoxml">
           <preface><foreword>
-          <recommendation id="_" obligation="shall,could"   keep-with-next="true" keep-lines-together="true" model="default">
+          <recommendation id="A" obligation="shall,could"   keep-with-next="true" keep-lines-together="true" model="default">
         <identifier>/ogc/recommendation/wfs/2</identifier>
         <inherit>/ss/584/2015/level/1</inherit>
         <classification><tag>type</tag><value>text</value></classification>
@@ -323,7 +474,7 @@ RSpec.describe Metanorma::Requirements::Default do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -346,39 +497,87 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     presxml = <<~OUTPUT
-          <foreword displayorder="2">
-          <title>Foreword</title>
-          <recommendation id="_" obligation="shall,could" keep-with-next="true" keep-lines-together="true" model="default"><name>Recommendation 1:<br/>/ogc/recommendation/wfs/2</name><p><em>Obligation: shall,could</em><br/>
-      <em>Subject: user</em><br/>
-      <em>Inherits: /ss/584/2015/level/1</em><br/>
-      <em>Type: text</em><br/>
-      <em>Language: BASIC</em></p><div type="requirement-description">
-          <p id="_">I recommend <em>this</em>.</p>
-        </div><div type="requirement-description">
-          <p id="_">As for the measurement targets,</p>
-        </div><div exclude="false" type="requirement-measurement-target">
-          <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_"><name>(1)</name>
-            <stem type="AsciiMath">r/1 = 0</stem>
-          </formula>
-        </div><div exclude="false" type="requirement-verification">
-          <p id="_">The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
-            if (success)
-            recommendation(label: success-response)
-            end
-          </sourcecode>
-        </div><div exclude="false" class="component1" type="requirement-component1">
-                  <p id="_">Hello</p>
-                </div></recommendation>
-          </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <recommendation id="A" obligation="shall,could" keep-with-next="true" keep-lines-together="true" model="default" autonum="1">
+             <fmt-name>
+                <span class="fmt-caption-label">
+                   <span class="fmt-element-name">Recommendation</span>
+                   <semx element="autonum" source="A">1</semx>
+                </span>
+                :
+                <br/>
+                /ogc/recommendation/wfs/2
+             </fmt-name>
+             <p>
+                <em>Obligation: shall,could</em>
+                <br/>
+                <em>Subject: user</em>
+                <br/>
+                <em>Inherits: /ss/584/2015/level/1</em>
+                <br/>
+                <em>Type: text</em>
+                <br/>
+                <em>Language: BASIC</em>
+             </p>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="A">1</semx>
+             </fmt-xref-label>
+             <div type="requirement-description">
+                <p id="_">
+                   I recommend
+                   <em>this</em>
+                   .
+                </p>
+             </div>
+             <div type="requirement-description">
+                <p id="_">As for the measurement targets,</p>
+             </div>
+             <div exclude="false" type="requirement-measurement-target">
+                <p id="_">The measurement target shall be measured as:</p>
+                <formula id="B" autonum="1">
+                   <fmt-name>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-autonum-delim">(</span>
+                         1
+                         <span class="fmt-autonum-delim">)</span>
+                      </span>
+                   </fmt-name>
+                   <fmt-xref-label>
+                      <span class="fmt-element-name">Formula</span>
+                      <span class="fmt-autonum-delim">(</span>
+                      <semx element="autonum" source="B">1</semx>
+                      <span class="fmt-autonum-delim">)</span>
+                   </fmt-xref-label>
+                   <stem type="AsciiMath">r/1 = 0</stem>
+                </formula>
+             </div>
+             <div exclude="false" type="requirement-verification">
+                <p id="_">The following code will be run for verification:</p>
+                <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
+             if (success)
+             recommendation(label: success-response)
+             end
+           </sourcecode>
+             </div>
+             <div exclude="false" class="component1" type="requirement-component1">
+                <p id="_">Hello</p>
+             </div>
+          </recommendation>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
 
     out = Nokogiri::XML(
@@ -386,10 +585,13 @@ RSpec.describe Metanorma::Requirements::Default do
       .convert("test", input
       .sub("<recommendation ", "<recommendation class='provision' "), true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n
         .format(presxml.sub("<recommendation ",
                             "<recommendation class='provision' ")
-      .sub("Recommendation 1:", "Provision 1:"))
+      .gsub(/<fmt-name>\s*<span class="fmt-caption-label">\s*<span class="fmt-element-name">Recommendation/,
+            '<fmt-name><span class="fmt-caption-label"><span class="fmt-element-name">Provision')
+      .gsub(/<fmt-xref-label>\s*<span class="fmt-element-name">Recommendation/,
+            '<fmt-xref-label><span class="fmt-element-name">provision'))
   end
 end

--- a/spec/default/render_spec.rb
+++ b/spec/default/render_spec.rb
@@ -76,11 +76,17 @@ RSpec.describe Metanorma::Requirements::Default do
                 <span class="fmt-caption-label">
                    <span class="fmt-element-name">Permission</span>
                    <semx element="autonum" source="A">1</semx>
+                   <span class="fmt-caption-delim">
+                      :
+                      <br/>
+                   </span>
+                   <semx element="identifier" source="A">/ogc/recommendation/wfs/2</semx>
                 </span>
-                :
-                <br/>
-                /ogc/recommendation/wfs/2
              </fmt-name>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="A">1</semx>
+             </fmt-xref-label>
              <p>
                 <em>Subject: user</em>
                 <br/>
@@ -101,10 +107,6 @@ RSpec.describe Metanorma::Requirements::Default do
                 <br/>
                 <em>Family: System and Communications Protocols</em>
              </p>
-             <fmt-xref-label>
-                <span class="fmt-element-name">Permission</span>
-                <semx element="autonum" source="A">1</semx>
-             </fmt-xref-label>
              <div type="requirement-description">
                 <p id="_">
                    I recommend
@@ -239,20 +241,24 @@ RSpec.describe Metanorma::Requirements::Default do
              <fmt-name>
                 <span class="fmt-caption-label">
                    <span class="fmt-element-name">Requirement</span>
+                   <span class="fmt-caption-delim">
+                      :
+                      <br/>
+                   </span>
+                   <semx element="identifier" source="A">/ogc/recommendation/wfs/2</semx>
+                   .
+                   <semx element="title" source="A">A New Requirement</semx>
                 </span>
-                :
-                <br/>
-                /ogc/recommendation/wfs/2. A New Requirement
              </fmt-name>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="A">(??)</semx>
+             </fmt-xref-label>
              <p>
                 <em>Subject: user</em>
                 <br/>
                 <em>Inherits: /ss/584/2015/level/1</em>
              </p>
-             <fmt-xref-label>
-                <span class="fmt-element-name">Requirement</span>
-                <semx element="autonum" source="A">(??)</semx>
-             </fmt-xref-label>
              <div type="requirement-description">
                 <p id="_">
                    I recommend
@@ -375,20 +381,24 @@ RSpec.describe Metanorma::Requirements::Default do
              <fmt-name>
                 <span class="fmt-caption-label">
                    <span class="fmt-element-name">Exigence</span>
+                   <span class="fmt-caption-delim">
+                      :
+                      <br/>
+                   </span>
+                   <semx element="identifier" source="A">/ogc/recommendation/wfs/2</semx>
+                   .
+                   <semx element="title" source="A">A New Requirement</semx>
                 </span>
-                :
-                <br/>
-                /ogc/recommendation/wfs/2. A New Requirement
              </fmt-name>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="A">(??)</semx>
+             </fmt-xref-label>
              <p>
                 <em>Sujet : user</em>
                 <br/>
                 <em>Hérite : /ss/584/2015/level/1</em>
              </p>
-             <fmt-xref-label>
-                <span class="fmt-element-name">Exigence</span>
-                <semx element="autonum" source="A">(??)</semx>
-             </fmt-xref-label>
              <div type="requirement-description">
                 <p id="_">
                    I recommend
@@ -509,11 +519,17 @@ RSpec.describe Metanorma::Requirements::Default do
                 <span class="fmt-caption-label">
                    <span class="fmt-element-name">Recommendation</span>
                    <semx element="autonum" source="A">1</semx>
+                   <span class="fmt-caption-delim">
+                      :
+                      <br/>
+                   </span>
+                   <semx element="identifier" source="A">/ogc/recommendation/wfs/2</semx>
                 </span>
-                :
-                <br/>
-                /ogc/recommendation/wfs/2
              </fmt-name>
+             <fmt-xref-label>
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="A">1</semx>
+             </fmt-xref-label>
              <p>
                 <em>Obligation: shall,could</em>
                 <br/>
@@ -525,10 +541,6 @@ RSpec.describe Metanorma::Requirements::Default do
                 <br/>
                 <em>Language: BASIC</em>
              </p>
-             <fmt-xref-label>
-                <span class="fmt-element-name">Recommendation</span>
-                <semx element="autonum" source="A">1</semx>
-             </fmt-xref-label>
              <div type="requirement-description">
                 <p id="_">
                    I recommend

--- a/spec/default/xref_spec.rb
+++ b/spec/default/xref_spec.rb
@@ -80,41 +80,41 @@ RSpec.describe Metanorma::Requirements::Default do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="N3">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Provision</span>
                 <semx element="autonum" source="N3">1</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -215,34 +215,34 @@ RSpec.describe Metanorma::Requirements::Default do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Exigence</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Exigence</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Exigence</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Exigence</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Exigence</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -342,34 +342,34 @@ RSpec.describe Metanorma::Requirements::Default do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -469,34 +469,34 @@ RSpec.describe Metanorma::Requirements::Default do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -580,35 +580,35 @@ RSpec.describe Metanorma::Requirements::Default do
              <xref target="N1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="xyz">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="xyz">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N2">1-1</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="xyz">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N">1-1-1</semx>
              </xref>
              <xref target="Q1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="xyz">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="Q1">1-1</semx>
              </xref>
              <xref target="R1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="xyz">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="R1">1-1</semx>
              </xref>

--- a/spec/default/xref_spec.rb
+++ b/spec/default/xref_spec.rb
@@ -70,24 +70,72 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-          <foreword displayorder='2'>
-          <title>Foreword</title>
-            <p>
-              <xref target='N1'>Introduction, Requirement 1</xref>
-      <xref target='N2'>Preparatory, Requirement (??)</xref>
-      <xref target='N'>Clause 1, Requirement 2</xref>
-      <xref target="N3">Clause 1, Provision 1</xref>
-      <xref target='note1'>Clause 3.1, Requirement 3</xref>
-      <xref target='note2'>Clause 3.1, Requirement 4</xref>
-      <xref target='AN'>Requirement A.1</xref>
-      <xref target='Anote1'>Requirement (??)</xref>
-      <xref target='Anote2'>Requirement A.2</xref>
-            </p>
-          </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="N3">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Provision</span>
+                <semx element="autonum" source="N3">1</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -157,23 +205,65 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-          <foreword displayorder='2'>
-          <title>Avant-propos</title>
-            <p>
-              <xref target='N1'>Introduction, Exigence 1</xref>
-      <xref target='N2'>Preparatory, Exigence (??)</xref>
-      <xref target='N'>Article 1, Exigence 2</xref>
-      <xref target='note1'>Article 3.1, Exigence 3</xref>
-      <xref target='note2'>Article 3.1, Exigence 4</xref>
-      <xref target='AN'>Exigence A.1</xref>
-      <xref target='Anote1'>Exigence (??)</xref>
-      <xref target='Anote2'>Exigence A.2</xref>
-            </p>
-          </foreword>
+      <foreword displayorder="2">
+          <title id="_">Avant-propos</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Avant-propos</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Exigence</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -242,23 +332,65 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-          <foreword displayorder='2'>
-          <title>Foreword</title>
-            <p>
-              <xref target='N1'>Introduction, Recommendation 1</xref>
-      <xref target='N2'>Preparatory, Recommendation (??)</xref>
-      <xref target='N'>Clause 1, Recommendation 2</xref>
-      <xref target='note1'>Clause 3.1, Recommendation 3</xref>
-      <xref target='note2'>Clause 3.1, Recommendation 4</xref>
-      <xref target='AN'>Recommendation A.1</xref>
-      <xref target='Anote1'>Recommendation (??)</xref>
-      <xref target='Anote2'>Recommendation A.2</xref>
-            </p>
-          </foreword>
+       <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -327,23 +459,65 @@ RSpec.describe Metanorma::Requirements::Default do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-                 <foreword displayorder='2'>
-          <title>Foreword</title>
-                   <p>
-                     <xref target='N1'>Introduction, Permission 1</xref>
-      <xref target='N2'>Preparatory, Permission (??)</xref>
-      <xref target='N'>Clause 1, Permission 2</xref>
-      <xref target='note1'>Clause 3.1, Permission 3</xref>
-      <xref target='note2'>Clause 3.1, Permission 4</xref>
-      <xref target='AN'>Permission A.1</xref>
-      <xref target='Anote1'>Permission (??)</xref>
-      <xref target='Anote2'>Permission A.2</xref>
-                   </p>
-                 </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -395,25 +569,75 @@ RSpec.describe Metanorma::Requirements::Default do
       </iso-standard>
     INPUT
     output = <<~OUTPUT
-                <foreword displayorder='2'>
-          <title>Foreword</title>
-                  <p>
-                     <xref target='N1'>Clause 1, Permission 1</xref>
-      <xref target='N2'>Clause 1, Permission 1-1</xref>
-      <xref target='N'>Clause 1, Permission 1-1-1</xref>
-      <xref target='Q1'>Clause 1, Requirement 1-1</xref>
-      <xref target='R1'>Clause 1, Recommendation 1-1</xref>
-      <xref target='AN1'>Permission A.1</xref>
-      <xref target='AN2'>Permission A.1-1</xref>
-      <xref target='AN'>Permission A.1-1-1</xref>
-      <xref target='AQ1'>Requirement A.1-1</xref>
-      <xref target='AR1'>Recommendation A.1-1</xref>
-                  </p>
-                </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="xyz">1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="xyz">1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N2">1-1</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="xyz">1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N">1-1-1</semx>
+             </xref>
+             <xref target="Q1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="xyz">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Q1">1-1</semx>
+             </xref>
+             <xref target="R1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="xyz">1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="R1">1-1</semx>
+             </xref>
+             <xref target="AN1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="AN1">A.1</semx>
+             </xref>
+             <xref target="AN2">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="AN2">A.1-1</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="AN">A.1-1-1</semx>
+             </xref>
+             <xref target="AQ1">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="AQ1">A.1-1</semx>
+             </xref>
+             <xref target="AR1">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="AR1">A.1-1</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri.XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 end

--- a/spec/modspec/identifier_spec.rb
+++ b/spec/modspec/identifier_spec.rb
@@ -63,10 +63,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                      <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                      </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -132,10 +134,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -263,10 +267,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -332,10 +338,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -464,10 +472,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                      </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -533,10 +543,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -664,10 +676,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -733,10 +747,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -864,10 +880,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -933,10 +951,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>

--- a/spec/modspec/identifier_spec.rb
+++ b/spec/modspec/identifier_spec.rb
@@ -51,116 +51,154 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/ogc/recommendation/wfs/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1" style="id">/ogc/recommendation/wfs/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                      <xref target="B1">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>/ogc/recommendation/wfs/10</tt>
+                      </xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Statement</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1" style="id">/ogc/recommendation/wfs/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <p>
+             <xref target="A1">
+                <span class="fmt-element-name">Permissions class</span>
+                <semx element="autonum" source="A1">1</semx>
+                :
                 <tt>/ogc/recommendation/wfs/2</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/ogc/recommendation/wfs/10</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1' style='id'>/ogc/recommendation/wfs/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-                <xref target='B1'>Permission 1: <tt>/ogc/recommendation/wfs/10</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
+             </xref>
+             <xref target="B1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="B1">1</semx>
+                :
                 <tt>/ogc/recommendation/wfs/10</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/ogc/recommendation/wfs/2</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Statement</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1' style='id'>/ogc/recommendation/wfs/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <xref target='A1'>
-            Permissions class 1:
-            <tt>/ogc/recommendation/wfs/2</tt>
-          </xref>
-          <xref target='B1'>
-            Permission 1:
-            <tt>/ogc/recommendation/wfs/10</tt>
-          </xref>
-          <xref target='A1' style='id'>A1</xref>
-          <xref target='B1' style='id'>B1</xref>
-          <xref target='A1' style='id'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1' style='id'>/ogc/recommendation/wfs/10</xref>
-          <xref target='A'>/ogc/recommendation/wfs/2</xref>
-          <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-        </p>
-      </foreword>
+             </xref>
+             <xref target="A1" style="id">A1</xref>
+             <xref target="B1" style="id">B1</xref>
+             <xref target="A1" style="id">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1" style="id">/ogc/recommendation/wfs/10</xref>
+             <xref target="A">/ogc/recommendation/wfs/2</xref>
+             <xref target="A1">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1">/ogc/recommendation/wfs/10</xref>
+          </p>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -213,116 +251,153 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/recommendation/wfs/2</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/recommendation/wfs/10</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/recommendation/wfs/2</xref>
-                <xref target='B1' style='id'>/recommendation/wfs/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-                <xref target='B1'>Permission 1: <tt>/recommendation/wfs/10</tt></xref>
-
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/recommendation/wfs/10</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/recommendation/wfs/2</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Statement</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/recommendation/wfs/2</xref>
-                <xref target='B1' style='id'>/recommendation/wfs/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <xref target='A1'>
-            Permissions class 1:
-            <tt>/ogc/recommendation/wfs/2</tt>
-          </xref>
-          <xref target='B1'>
-            Permission 1:
-            <tt>/ogc/recommendation/wfs/10</tt>
-          </xref>
-          <xref target='A1' style='id'>A1</xref>
-          <xref target='B1' style='id'>B1</xref>
-          <xref target='A1' style='id'>/recommendation/wfs/2</xref>
-          <xref target='B1' style='id'>/recommendation/wfs/10</xref>
-          <xref target='A'>/ogc/recommendation/wfs/2</xref>
-          <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-        </p>
-      </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/recommendation/wfs/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/recommendation/wfs/2</xref>
+                      <xref target="B1" style="id">/recommendation/wfs/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                      <xref target="B1">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>/recommendation/wfs/10</tt>
+                      </xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/recommendation/wfs/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Statement</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/recommendation/wfs/2</xref>
+                      <xref target="B1" style="id">/recommendation/wfs/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <p>
+             <xref target="A1">
+                <span class="fmt-element-name">Permissions class</span>
+                <semx element="autonum" source="A1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/2</tt>
+             </xref>
+             <xref target="B1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="B1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/10</tt>
+             </xref>
+             <xref target="A1" style="id">A1</xref>
+             <xref target="B1" style="id">B1</xref>
+             <xref target="A1" style="id">/recommendation/wfs/2</xref>
+             <xref target="B1" style="id">/recommendation/wfs/10</xref>
+             <xref target="A">/ogc/recommendation/wfs/2</xref>
+             <xref target="A1">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1">/ogc/recommendation/wfs/10</xref>
+          </p>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({ modspecidentifierbase: "/ogc" })
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -377,115 +452,153 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/2</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/10</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/2</xref>
-                <xref target='B1' style='id'>/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-                <xref target='B1'>Permission 1: <tt>/10</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/wfs/10</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/wfs/2</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Statement</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/wfs/2</xref>
-                <xref target='B1' style='id'>/wfs/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <xref target='A1'>
-            Permissions class 1:
-            <tt>/ogc/recommendation/wfs/2</tt>
-          </xref>
-          <xref target='B1'>
-            Permission 1:
-            <tt>/ogc/recommendation/wfs/10</tt>
-          </xref>
-          <xref target='A1' style='id'>A1</xref>
-          <xref target='B1' style='id'>B1</xref>
-          <xref target='A1' style='id'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1' style='id'>/ogc/recommendation/wfs/10</xref>
-          <xref target='A'>/ogc/recommendation/wfs/2</xref>
-          <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-        </p>
-                  </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/2</xref>
+                      <xref target="B1" style="id">/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                      <xref target="B1">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>/10</tt>
+                      </xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/wfs/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Statement</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/wfs/2</xref>
+                      <xref target="B1" style="id">/wfs/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <p>
+             <xref target="A1">
+                <span class="fmt-element-name">Permissions class</span>
+                <semx element="autonum" source="A1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/2</tt>
+             </xref>
+             <xref target="B1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="B1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/10</tt>
+             </xref>
+             <xref target="A1" style="id">A1</xref>
+             <xref target="B1" style="id">B1</xref>
+             <xref target="A1" style="id">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1" style="id">/ogc/recommendation/wfs/10</xref>
+             <xref target="A">/ogc/recommendation/wfs/2</xref>
+             <xref target="A1">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1">/ogc/recommendation/wfs/10</xref>
+          </p>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -539,115 +652,153 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/2</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/10</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/2</xref>
-                <xref target='B1' style='id'>/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-                <xref target='B1'>Permission 1: <tt>/10</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/10</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/2</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Statement</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/2</xref>
-                <xref target='B1' style='id'>/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <xref target='A1'>
-            Permissions class 1:
-            <tt>/ogc/recommendation/wfs/2</tt>
-          </xref>
-          <xref target='B1'>
-            Permission 1:
-            <tt>/ogc/recommendation/wfs/10</tt>
-          </xref>
-          <xref target='A1' style='id'>A1</xref>
-          <xref target='B1' style='id'>B1</xref>
-          <xref target='A1' style='id'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1' style='id'>/ogc/recommendation/wfs/10</xref>
-          <xref target='A'>/ogc/recommendation/wfs/2</xref>
-          <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-        </p>
-                  </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/2</xref>
+                      <xref target="B1" style="id">/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                      <xref target="B1">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>/10</tt>
+                      </xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Statement</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/2</xref>
+                      <xref target="B1" style="id">/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <p>
+             <xref target="A1">
+                <span class="fmt-element-name">Permissions class</span>
+                <semx element="autonum" source="A1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/2</tt>
+             </xref>
+             <xref target="B1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="B1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/10</tt>
+             </xref>
+             <xref target="A1" style="id">A1</xref>
+             <xref target="B1" style="id">B1</xref>
+             <xref target="A1" style="id">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1" style="id">/ogc/recommendation/wfs/10</xref>
+             <xref target="A">/ogc/recommendation/wfs/2</xref>
+             <xref target="A1">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1">/ogc/recommendation/wfs/10</xref>
+          </p>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -701,115 +852,153 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/2</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/10</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Description</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/2</xref>
-                <xref target='B1' style='id'>/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-                <xref target='B1'>Permission 1: <tt>/10</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Identifier</th>
-              <td>
-                <tt>/10</tt>
-              </td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/2</tt>
-                </xref>
-              </td>
-            </tr>
-            <tr>
-              <th>Statement</th>
-              <td>
-                <xref target='A' style='id'>/ogc/recommendation/wfs/2</xref>
-                <xref target='A1' style='id'>/2</xref>
-                <xref target='B1' style='id'>/10</xref>
-                <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-                <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p>
-          <xref target='A1'>
-            Permissions class 1:
-            <tt>/ogc/recommendation/wfs/2</tt>
-          </xref>
-          <xref target='B1'>
-            Permission 1:
-            <tt>/ogc/recommendation/wfs/10</tt>
-          </xref>
-          <xref target='A1' style='id'>A1</xref>
-          <xref target='B1' style='id'>B1</xref>
-          <xref target='A1' style='id'>/recommendation/wfs/2</xref>
-          <xref target='B1' style='id'>/recommendation/wfs/10</xref>
-          <xref target='A'>/ogc/recommendation/wfs/2</xref>
-          <xref target='A1'>/ogc/recommendation/wfs/2</xref>
-          <xref target='B1'>/ogc/recommendation/wfs/10</xref>
-        </p>
-                  </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/2</xref>
+                      <xref target="B1" style="id">/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                      <xref target="B1">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>/10</tt>
+                      </xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Statement</th>
+                   <td>
+                      <xref target="A" style="id">/ogc/recommendation/wfs/2</xref>
+                      <xref target="A1" style="id">/2</xref>
+                      <xref target="B1" style="id">/10</xref>
+                      <xref target="A1">/ogc/recommendation/wfs/2</xref>
+                      <xref target="B1">/ogc/recommendation/wfs/10</xref>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <p>
+             <xref target="A1">
+                <span class="fmt-element-name">Permissions class</span>
+                <semx element="autonum" source="A1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/2</tt>
+             </xref>
+             <xref target="B1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="B1">1</semx>
+                :
+                <tt>/ogc/recommendation/wfs/10</tt>
+             </xref>
+             <xref target="A1" style="id">A1</xref>
+             <xref target="B1" style="id">B1</xref>
+             <xref target="A1" style="id">/recommendation/wfs/2</xref>
+             <xref target="B1" style="id">/recommendation/wfs/10</xref>
+             <xref target="A">/ogc/recommendation/wfs/2</xref>
+             <xref target="A1">/ogc/recommendation/wfs/2</xref>
+             <xref target="B1">/ogc/recommendation/wfs/10</xref>
+          </p>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({ modspecidentifierbase: "/ogc" })
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 end

--- a/spec/modspec/requirement_components_spec.rb
+++ b/spec/modspec/requirement_components_spec.rb
@@ -44,15 +44,25 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     presxml = <<~OUTPUT
       <foreword id="A" displayorder="2">
-        <title>Preface</title>
-        <table id="_" class="modspec" type="recommend">
-          <thead>
-            <tr>
-              <th scope="colgroup" colspan="2">
-                <p class="RecommendationTitle">Recommendation 1</p>
-              </th>
-            </tr>
-          </thead>
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="_" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Recommendation</span>
+                            <semx element="autonum" source="_">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
           <tbody>
             <tr>
               <th>Identifier</th>
@@ -185,7 +195,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -214,15 +224,25 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     presxml = <<~OUTPUT
       <foreword id="A" displayorder="2">
-         <title>Preface</title>
-         <table id="_" class="modspec" type="recommend">
-           <thead>
-             <tr>
-               <th scope="colgroup" colspan="2">
-                 <p class="RecommendationTitle">Recommendation 1</p>
-               </th>
-             </tr>
-           </thead>
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="_" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Recommendation</span>
+                            <semx element="autonum" source="_">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
            <tbody>
              <tr>
                <th>Identifier</th>
@@ -284,7 +304,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -325,63 +345,72 @@ RSpec.describe Metanorma::Requirements::Modspec do
             </ogc-standard>
     INPUT
     presxml = <<~PRESXML
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Requirement 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Test method type</th>
-              <td>
-                <p id='_'>Manual Inspection</p>
-              </td>
-            </tr>
-            <tr>
-              <th>Test method</th>
-              <td>
-                <p id='1'>
-                  <ol class="steps">
-                    <li>
-                      <p id='2'>For each UML class defined or referenced in the Tunnel Package:</p>
-                      <ol class="steps">
-                        <li>
-                          <p id='3'>
-                             Validate that the Implementation Specification
-                            contains a data element which represents the same
-                            concept as that defined for the UML class.
-                          </p>
-                        </li>
-                        <li>
-                          <p id='4'>
-                             Validate that the data element has the same
-                            relationships with other elements as those defined for
-                            the UML class. Validate that those relationships have
-                            the same source, target, direction, roles, and
-                            multiplicies as those documented in the Conceptual
-                            Model.
-                          </p>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Requirement</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Test method type</th>
+                   <td>
+                      <p id="_">Manual Inspection</p>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Test method</th>
+                   <td>
+                      <p id="1">
+                         <ol class="steps">
+                            <li>
+                               <p id="2">For each UML class defined or referenced in the Tunnel Package:</p>
+                               <ol class="steps">
+                                  <li>
+                                     <p id="3">
+                   Validate that the Implementation Specification contains a data
+                   element which represents the same concept as that defined for
+                   the UML class.
+                 </p>
+                                  </li>
+                                  <li>
+                                     <p id="4">
+                   Validate that the data element has the same relationships with
+                   other elements as those defined for the UML class. Validate that
+                   those relationships have the same source, target, direction,
+                   roles, and multiplicies as those documented in the Conceptual
+                   Model.
+                 </p>
+                                  </li>
+                               </ol>
+                            </li>
+                         </ol>
+                      </p>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+       </foreword>
     PRESXML
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -408,104 +437,152 @@ RSpec.describe Metanorma::Requirements::Modspec do
       </ogc-standard>
     INPUT
     presxml = <<~PRESXML
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Requirement 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th>
-              <td><tt>/ogc/recommendation/wfs/1</tt></td>
-            </tr>
-            <tr>
-              <th>Conformance test</th>
-              <td>
-                <xref target='A2'>
-                  Conformance test 1:
-                  <tt>/ogc/recommendation/wfs/2</tt>
-                </xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='A2' class='modspec' type='recommendtest'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTestTitle'>Conformance test 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th><td><tt>/ogc/recommendation/wfs/2</tt></td>
-            </tr>
-            <tr>
-              <th>Requirement</th>
-              <td>
-                <xref target='A1'>Requirement 1: <tt>/ogc/recommendation/wfs/1</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='A3' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Requirements class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th>
-              <td><tt>/ogc/recommendation/wfs/3</tt></td>
-            </tr>
-            <tr>
-              <th>Conformance class</th>
-              <td>
-                <xref target='A4'>
-                  Conformance class 1:
-                  <tt>/ogc/recommendation/wfs/4</tt>
-                </xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='A4' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Conformance class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th>
-              <td><tt>/ogc/recommendation/wfs/4</tt></td>
-            </tr>
-            <tr>
-              <th>Requirements class</th>
-              <td>
-                <xref target='A3'>Requirements class 1: <tt>/ogc/recommendation/wfs/3</tt></xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Requirement</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/1</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Conformance test</th>
+                   <td>
+                      <span class="fmt-element-name">Conformance test</span>
+                      <semx element="autonum" source="A2">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A2">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="A2" type="recommendtest" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTestTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Conformance test</span>
+                            <semx element="autonum" source="A2">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Requirement</th>
+                   <td>
+                      <span class="fmt-element-name">Requirement</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/1</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="A3" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Requirements class</span>
+                            <semx element="autonum" source="A3">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/3</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Conformance class</th>
+                   <td>
+                      <span class="fmt-element-name">Conformance class</span>
+                      <semx element="autonum" source="A4">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A4">/ogc/recommendation/wfs/4</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="A4" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Conformance class</span>
+                            <semx element="autonum" source="A4">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/4</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Requirements class</th>
+                   <td>
+                      <span class="fmt-element-name">Requirements class</span>
+                      <semx element="autonum" source="A3">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A3">/ogc/recommendation/wfs/3</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+       </foreword>
     PRESXML
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 end

--- a/spec/modspec/requirement_components_spec.rb
+++ b/spec/modspec/requirement_components_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Recommendation</span>
                             <semx element="autonum" source="_">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -235,10 +237,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Recommendation</span>
                             <semx element="autonum" source="_">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -357,10 +361,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Requirement</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -449,10 +455,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Requirement</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -482,10 +490,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTestTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Conformance test</span>
                             <semx element="autonum" source="A2">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -515,10 +525,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Requirements class</span>
                             <semx element="autonum" source="A3">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -548,10 +560,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Conformance class</span>
                             <semx element="autonum" source="A4">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>

--- a/spec/modspec/requirements_spec.rb
+++ b/spec/modspec/requirements_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -315,7 +315,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -407,7 +407,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -514,7 +514,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -661,7 +661,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -807,7 +807,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -929,7 +929,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -1009,7 +1009,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -1127,7 +1127,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 
@@ -1245,7 +1245,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
 
     presxml = <<~OUTPUT
@@ -1314,7 +1314,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       .convert("test", input
       .sub("<language>en</language>", "<language>fr</language>"), true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
 
     presxml = <<~OUTPUT
@@ -1379,7 +1379,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       .convert("test", input
       .sub("<recommendation ", "<recommendation class='Provision' "), true),
     ).at("//xmlns:foreword")
-    expect(Xml::C14n.format(out.to_xml))
+    expect(Xml::C14n.format(strip_guid(out.to_xml)))
       .to be_equivalent_to Xml::C14n.format(presxml)
   end
 end

--- a/spec/modspec/requirements_spec.rb
+++ b/spec/modspec/requirements_spec.rb
@@ -77,10 +77,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <table id="A1" class="modspec" type="recommend">
             <thead><tr><th scope="colgroup" colspan="2">
                           <p class="RecommendationTitle">
+                       <fmt-name>
                  <span class="fmt-caption-label">
                     <span class="fmt-element-name">Permission</span>
                     <semx element="autonum" source="A1">1</semx>
                  </span>
+                       </fmt-name>
               </p>
             </th></tr></thead>
             <tbody>
@@ -271,10 +273,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <th scope='colgroup' colspan='2'>
                 <p class="RecommendationTestTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Conformance test</span>
                      <semx element="autonum" source="A1">1</semx>
                   </span>
+                       </fmt-name>
                </p>
               </th>
             </tr>
@@ -429,10 +433,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <table id="A1" type="recommendtest" class="modspec">
       <thead><tr><th scope="colgroup" colspan="2">
                      <p class="RecommendationTestTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Abstract test</span>
                      <semx element="autonum" source="A1">1</semx>
                   </span>
+                       </fmt-name>
                </p>
         </th></tr></thead>
         <tbody>
@@ -523,10 +529,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permissions class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -588,10 +596,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -673,10 +683,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Conformance class</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -771,10 +783,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Conformance class</span>
                             <semx element="autonum" source="B">2</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -793,10 +807,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="B2">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -878,10 +894,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Classe de confirmité</span>
                             <semx element="autonum" source="A1">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -976,10 +994,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Classe de confirmité</span>
                             <semx element="autonum" source="B">2</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -998,10 +1018,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Autorisation</span>
                             <semx element="autonum" source="B2">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -1077,10 +1099,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
               <tr>
                 <th scope='colgroup' colspan='2'>
                 <p class="RecommendationTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Requirements class</span>
                      <semx element="autonum" source="A1">1</semx>
                   </span>
+                       </fmt-name>
                </p>
                 </th>
               </tr>
@@ -1157,10 +1181,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                 <tr>
                    <th scope="colgroup" colspan="2">
                       <p class="RecommendationTitle">
+                       <fmt-name>
                          <span class="fmt-caption-label">
                             <span class="fmt-element-name">Permission</span>
                             <semx element="autonum" source="A5">1</semx>
                          </span>
+                       </fmt-name>
                       </p>
                    </th>
                 </tr>
@@ -1232,10 +1258,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <th scope='colgroup' colspan='2'>
                 <p class="RecommendationTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Recommendations class</span>
                      <semx element="autonum" source="A1">1</semx>
                   </span>
+                       </fmt-name>
                </p>
               </th>
             </tr>
@@ -1362,9 +1390,13 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <th scope='colgroup' colspan='2'>
                 <p class="RecommendationTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Requirement</span>
+                     <span class="fmt-caption-delim">: </span>
+                        <semx element="title" source="A">A New Requirement</semx>
                   </span>
+                       </fmt-name>
                </p>
               </th>
             </tr>
@@ -1502,10 +1534,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <th scope='colgroup' colspan='2'>
                             <p class="RecommendationTitle">
+                       <fmt-name>
                  <span class="fmt-caption-label">
                     <span class="fmt-element-name">Recommendation</span>
                     <semx element="autonum" source="_">1</semx>
                  </span>
+                       </fmt-name>
               </p>
               </th>
             </tr>
@@ -1589,10 +1623,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
                <tr>
                   <th scope="colgroup" colspan="2">
                   <p class="RecommendationTitle">
+                       <fmt-name>
                  <span class="fmt-caption-label">
                     <span class="fmt-element-name">Recommandation</span>
                     <semx element="autonum" source="_">1</semx>
                  </span>
+                       </fmt-name>
               </p>
                   </th>
                </tr>
@@ -1680,10 +1716,12 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <th scope='colgroup' colspan='2'>
                 <p class="RecommendationTitle">
+                       <fmt-name>
                   <span class="fmt-caption-label">
                      <span class="fmt-element-name">Provision</span>
                      <semx element="autonum" source="_">1</semx>
                   </span>
+                       </fmt-name>
                </p>
               </th>
             </tr>

--- a/spec/modspec/requirements_spec.rb
+++ b/spec/modspec/requirements_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -67,9 +67,22 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-                <foreword id="A" displayorder="2"><title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
                 <table id="A1" class="modspec" type="recommend">
-            <thead><tr><th scope="colgroup" colspan="2"><p class="RecommendationTitle">Permission 1</p></th></tr></thead>
+            <thead><tr><th scope="colgroup" colspan="2">
+                          <p class="RecommendationTitle">
+                 <span class="fmt-caption-label">
+                    <span class="fmt-element-name">Permission</span>
+                    <semx element="autonum" source="A1">1</semx>
+                 </span>
+              </p>
+            </th></tr></thead>
             <tbody>
               <tr><th>Identifier</th><td><tt>/ogc/recommendation/wfs/2</tt></td></tr>
               <tr><th>Subject</th><td>user</td></tr>
@@ -104,8 +117,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
       <tr>
         <td colspan='2'>
           <p id='_'>The measurement target shall be measured as:</p>
-          <formula id='_'>
-            <name>(1)</name>
+            <formula id="B" autonum="1">
+                  <fmt-name>
+                     <span class="fmt-caption-label">
+                        <span class="fmt-autonum-delim">(</span>
+                        1
+                        <span class="fmt-autonum-delim">)</span>
+                     </span>
+                  </fmt-name>
+                  <fmt-xref-label>
+                     <span class="fmt-element-name">Formula</span>
+                     <span class="fmt-autonum-delim">(</span>
+                     <semx element="autonum" source="B">1</semx>
+                     <span class="fmt-autonum-delim">)</span>
+                  </fmt-xref-label>
             <stem type='AsciiMath'>r/1 = 0</stem>
           </formula>
         </td>
@@ -113,7 +138,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
       <tr>
         <td colspan='2'>
           <p id='_'>The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
+          <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
             if (success)
             recommendation(label: success-response)
             end
@@ -213,7 +238,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -234,13 +259,23 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
         <table id='A1' class='modspec' type='recommendtest'>
           <thead>
             <tr>
               <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTestTitle'>Conformance test 1</p>
+                <p class="RecommendationTestTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Conformance test</span>
+                     <semx element="autonum" source="A1">1</semx>
+                  </span>
+               </p>
               </th>
             </tr>
           </thead>
@@ -291,8 +326,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan="2">
                 <p id='_'>The measurement target shall be measured as:</p>
-                <formula id='_'>
-                  <name>(1)</name>
+                  <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formula</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
                   <stem type='AsciiMath'>r/1 = 0</stem>
                 </formula>
               </td>
@@ -300,7 +347,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The following code will be run for verification:</p>
-                <sourcecode id='_'>
+                <sourcecode id='_' autonum="2">
                   CoreRoot(success): HttpResponse if (success)
                   recommendation(label: success-response) end
                 </sourcecode>
@@ -352,7 +399,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -372,9 +419,22 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-              <foreword id="A" displayorder="2"><title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
           <table id="A1" type="recommendtest" class="modspec">
-      <thead><tr><th scope="colgroup" colspan="2"><p class="RecommendationTestTitle">Abstract test 1</p></th></tr></thead>
+      <thead><tr><th scope="colgroup" colspan="2">
+                     <p class="RecommendationTestTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Abstract test</span>
+                     <semx element="autonum" source="A1">1</semx>
+                  </span>
+               </p>
+        </th></tr></thead>
         <tbody>
           <tr>
           <th>Identifier</th>
@@ -388,13 +448,26 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p id="_">I recommend <em>this</em>.</p>
         </td></tr><tr><th>A</th><td>B</td></tr><tr><th>C</th><td>D</td></tr><tr><td colspan="2">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_"><name>(1)</name>
+            <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formula</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </td></tr><tr>
         <td colspan="2">
           <p id="_">The following code will be run for verification:</p>
-          <sourcecode id="_">CoreRoot(success): HttpResponse
+          <sourcecode id="_" autonum="2">CoreRoot(success): HttpResponse
             if (success)
             recommendation(label: success-response)
             end
@@ -438,76 +511,112 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
-        <table id='A1' keep-with-next='true' keep-lines-together='true' class='modspec' type='recommendclass'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permissions class 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th>
-              <td><tt>/ogc/recommendation/wfs/2</tt></td>
-            </tr>
-            <tr>
-              <th>Target type</th>
-              <td>user</td>
-            </tr>
-            <tr>
-              <th>Prerequisites</th>
-              <td>/ss/584/2015/level/1<br/>
-              /ss/584/2015/level/2</td>
-            </tr>
-            <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='B1'>
-                  Permission 1:
-                  <tt>/ogc/recommendation/wfs/10</tt>
-                </xref>
-                <br/>
-                  <xref target='A3'>
-                  Requirement 1-1:
-                  <tt>Requirement 1</tt>
-                </xref>
-              <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <table id='B1' class='modspec' type='recommend'>
-          <thead>
-            <tr>
-              <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Permission 1</p>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-            <th>Identifier</th>
-              <td><tt>/ogc/recommendation/wfs/10</tt></td>
-            </tr>
-            <tr>
-              <th>Included in</th>
-              <td>
-                <xref target='A1'>
-                  Permissions class 1:
-                  <tt>/ogc/recommendation/wfs/2</tt>
-                </xref>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </foreword>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" keep-with-next="true" keep-lines-together="true" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permissions class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Target type</th>
+                   <td>user</td>
+                </tr>
+                <tr>
+                   <th>Prerequisites</th>
+                   <td>
+                      /ss/584/2015/level/1
+                      <br/>
+                      /ss/584/2015/level/2
+                   </td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B1">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B1">/ogc/recommendation/wfs/10</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B1" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B1">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/10</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Permissions class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
@@ -552,109 +661,167 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-           <foreword id='A' displayorder='2'>
-             <title>Preface</title>
-             <table id='A1' class='modspec' type='recommendclass'>
-               <thead>
-                 <tr>
-                   <th scope='colgroup' colspan='2'>
-                     <p class='RecommendationTitle'>Conformance class 1</p>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Conformance class</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
                    </th>
-                 </tr>
-               </thead>
-               <tbody>
-                 <tr>
-                 <th>Identifier</th>
-                   <td><tt>/ogc/recommendation/wfs/2</tt></td>
-                 </tr>
-                 <tr>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
                    <th>Subject</th>
                    <td>user</td>
-                 </tr>
-                 <tr>
+                </tr>
+                <tr>
                    <th>Requirements class</th>
                    <td>
-                     <xref target='B'>Conformance class 2: <tt>ABC</tt></xref>
+                      <span class="fmt-element-name">Conformance class</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-                 <tr>
+                </tr>
+                <tr>
                    <th>Prerequisites</th>
-                   <td>/ss/584/2015/level/1<br/>
-                     <xref target='B'>Conformance class 2: <tt>ABC</tt></xref>
+                   <td>
+                      /ss/584/2015/level/1
+                      <br/>
+                      <span class="fmt-element-name">Conformance class</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-                 <tr>
+                </tr>
+                <tr>
                    <th>Indirect prerequisites</th>
                    <td>
-                     <link target='http://www.example.com/'/><br/>
-                     <xref target='B'>Conformance class 2: <tt>ABC</tt></xref>
+                      <link target="http://www.example.com/"/>
+                      <br/>
+                      <span class="fmt-element-name">Conformance class</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-                 <tr>
-            <th>Description</th>
-            <td>Hic incipit</td>
-          </tr>
-                 <tr>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>Hic incipit</td>
+                </tr>
+                <tr>
                    <th>Conformance tests</th>
                    <td>
-                     <xref target='B2'>
-                       Permission 1:
-                       <tt>Permission 1</tt>
-                     </xref>
-                   <br/>
-                     <xref target='A3'>
-                       Requirement 1-1:
-                       <tt>Requirement 1</tt>
-                     </xref>
-                   <br/>
-                     <xref target='A4'>
-                       Recommendation 1-1:
-                       <tt>Recommendation 1</tt>
-                     </xref>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="B2">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="B2">Permission 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
                    </td>
-                 </tr>
-               </tbody>
-             </table>
-             <table id='B' class='modspec' type='recommendclass'>
-               <thead>
-                 <tr>
-                   <th scope='colgroup' colspan='2'>
-                     <p class='RecommendationTitle'>Conformance class 2</p>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Conformance class</span>
+                            <semx element="autonum" source="B">2</semx>
+                         </span>
+                      </p>
                    </th>
-                 </tr>
-               </thead>
-               <tbody>
-                 <tr>
-                 <th>Identifier</th>
-                   <td><tt>ABC</tt></td>
-                 </tr>
-               </tbody>
-             </table>
-             <table id='B2' class='modspec' type='recommend'>
-        <thead>
-          <tr>
-            <th scope='colgroup' colspan='2'>
-              <p class='RecommendationTitle'>Permission 1</p>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-          <th>Identifier</th>
-            <td><tt>Permission 1</tt></td>
-          </tr>
-          <tr>
-            <th>Included in</th>
-            <td>
-              <xref target='A1'>
-                Conformance class 1:
-                <tt>/ogc/recommendation/wfs/2</tt>
-              </xref>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-           </foreword>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>ABC</tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B2" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="B2">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>Permission 1</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Conformance class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
@@ -699,109 +866,167 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-           <foreword id='A' displayorder='2'>
-             <title>Preface</title>
-             <table id='A1' class='modspec' type='recommendclass'>
-               <thead>
-                 <tr>
-                   <th scope='colgroup' colspan='2'>
-                     <p class='RecommendationTitle'>Classe de confirmit&#xE9; 1</p>
+      <foreword id="A" displayorder="2">
+          <title id="_">Preface</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Preface</semx>
+             </span>
+          </fmt-title>
+          <table id="A1" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Classe de confirmité</span>
+                            <semx element="autonum" source="A1">1</semx>
+                         </span>
+                      </p>
                    </th>
-                 </tr>
-               </thead>
-               <tbody>
-                 <tr>
-                 <th>Identifiant</th>
-                   <td><tt>/ogc/recommendation/wfs/2</tt></td>
-                 </tr>
-                 <tr>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifiant</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
                    <th>Sujet</th>
                    <td>user</td>
-                 </tr>
-                 <tr>
-                   <th>Classe d&#x2019;exigences</th>
+                </tr>
+                <tr>
+                   <th>Classe d’exigences</th>
                    <td>
-                     <xref target='B'>Classe de confirmit&#xE9; 2&#xA0;: <tt>ABC</tt></xref>
+                      <span class="fmt-element-name">Classe de confirmité</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-                 <tr>
-                   <th>Pr&#xE9;requis</th>
-                   <td>/ss/584/2015/level/1<br/>
-                     <xref target='B'>Classe de confirmit&#xE9; 2&#xA0;: <tt>ABC</tt></xref>
-                   </td>
-                 </tr>
-                 <tr>
-                   <th>Pr&#xE9;requis indirect</th>
+                </tr>
+                <tr>
+                   <th>Prérequis</th>
                    <td>
-                     <link target='http://www.example.com/'/><br/>
-                     <xref target='B'>Classe de confirmit&#xE9; 2&#xA0;: <tt>ABC</tt></xref>
+                      /ss/584/2015/level/1
+                      <br/>
+                      <span class="fmt-element-name">Classe de confirmité</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-                 <tr>
-            <th>Description</th>
-            <td>Hic incipit</td>
-          </tr>
-                 <tr>
-                   <th>Tests de conformit&#xE9;</th>
+                </tr>
+                <tr>
+                   <th>Prérequis indirect</th>
                    <td>
-                     <xref target='B2'>
-                       Autorisation 1&#xA0;:
-                       <tt>Permission 1</tt>
-                     </xref>
-                   <br/>
-                     <xref target='A3'>
-                       Exigence 1-1&#xA0;:
-                       <tt>Requirement 1</tt>
-                     </xref>
-                   <br/>
-                     <xref target='A4'>
-                       Recommandation 1-1&#xA0;:
-                       <tt>Recommendation 1</tt>
-                     </xref>
+                      <link target="http://www.example.com/"/>
+                      <br/>
+                      <span class="fmt-element-name">Classe de confirmité</span>
+                      <semx element="autonum" source="B">2</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="B">ABC</xref>
+                      </tt>
                    </td>
-                 </tr>
-               </tbody>
-             </table>
-             <table id='B' class='modspec' type='recommendclass'>
-               <thead>
-                 <tr>
-                   <th scope='colgroup' colspan='2'>
-                     <p class='RecommendationTitle'>Classe de confirmit&#xE9; 2</p>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>Hic incipit</td>
+                </tr>
+                <tr>
+                   <th>Tests de conformité</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Autorisation</span>
+                         <semx element="autonum" source="B2">1</semx>
+                          :
+                         <tt>
+                            <xref style="id" target="B2">Permission 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Exigence</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                          :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommandation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                          :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B" type="recommendclass" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Classe de confirmité</span>
+                            <semx element="autonum" source="B">2</semx>
+                         </span>
+                      </p>
                    </th>
-                 </tr>
-               </thead>
-               <tbody>
-                 <tr>
-                 <th>Identifiant</th>
-                   <td><tt>ABC</tt></td>
-                 </tr>
-               </tbody>
-             </table>
-             <table id='B2' class='modspec' type='recommend'>
-        <thead>
-          <tr>
-            <th scope='colgroup' colspan='2'>
-              <p class='RecommendationTitle'>Autorisation 1</p>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-          <th>Identifiant</th>
-            <td><tt>Permission 1</tt></td>
-          </tr>
-          <tr>
-            <th>Inclus dans</th>
-            <td>
-              <xref target='A1'>
-                 Classe de confirmit&#xE9; 1&#xA0;:
-                <tt>/ogc/recommendation/wfs/2</tt>
-              </xref>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-           </foreword>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifiant</th>
+                   <td>
+                      <tt>ABC</tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+          <table id="B2" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Autorisation</span>
+                            <semx element="autonum" source="B2">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifiant</th>
+                   <td>
+                      <tt>Permission 1</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Inclus dans</th>
+                   <td>
+                      <span class="fmt-element-name">Classe de confirmité</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
+          </table>
+       </foreword>
     OUTPUT
     out = Nokogiri::XML(
       IsoDoc::PresentationXMLConvert.new({})
@@ -840,89 +1065,127 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-        <foreword id='A' displayorder='2'>
-          <title>Preface</title>
+      <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
           <table id='A1' class='modspec' type='recommendclass'>
             <thead>
               <tr>
                 <th scope='colgroup' colspan='2'>
-                  <p class='RecommendationTitle'>Requirements class 1</p>
+                <p class="RecommendationTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Requirements class</span>
+                     <semx element="autonum" source="A1">1</semx>
+                  </span>
+               </p>
                 </th>
               </tr>
             </thead>
-            <tbody>
-              <tr>
-              <th>Identifier</th>
-                <td><tt>/ogc/recommendation/wfs/2</tt></td>
-              </tr>
-              <tr>
-                <th>Target type</th>
-                <td>user</td>
-              </tr>
-              <tr>
-                <th>Prerequisites</th>
-                <td>/ss/584/2015/level/1<br/>
-                /ss/584/2015/level/2</td>
-              </tr>
-              <tr>
-              <th>Implements</th>
-        <td>
-          <xref target='A5'>
-            Permission 1:
-            <tt>Permission 1</tt>
-          </xref>
-        </td>
-      </tr>
-      <tr>
-          <th>Description</th>
-         <td>Hic incipit</td>
-       </tr>
-              <tr>
-                <th>Normative statements</th>
-                <td>
-                  <xref target='A5'>
-                    Permission 1:
-                    <tt>Permission 1</tt>
-                  </xref>
-                <br/>
-                  <xref target='A3'>
-                    Requirement 1-1:
-                    <tt>Requirement 1</tt>
-                  </xref>
-                <br/>
-                  <xref target='A4'>
-                    Recommendation 1-1:
-                    <tt>Recommendation 1</tt>
-                  </xref>
-                </td>
-              </tr>
-            </tbody>
+                         <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>/ogc/recommendation/wfs/2</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Target type</th>
+                   <td>user</td>
+                </tr>
+                <tr>
+                   <th>Prerequisites</th>
+                   <td>
+                      /ss/584/2015/level/1
+                      <br/>
+                      /ss/584/2015/level/2
+                   </td>
+                </tr>
+                <tr>
+                   <th>Implements</th>
+                   <td>
+                      <span class="fmt-element-name">Permission</span>
+                      <semx element="autonum" source="A5">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A5">Permission 1</xref>
+                      </tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Description</th>
+                   <td>Hic incipit</td>
+                </tr>
+                <tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="A5">1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A5">Permission 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Requirement</span>
+                         <semx element="autonum" source="A3">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
+             </tbody>
           </table>
-          <table id='A5' class='modspec' type='recommend'>
-            <thead>
-              <tr>
-                <th scope='colgroup' colspan='2'>
-                  <p class='RecommendationTitle'>Permission 1</p>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-              <th>Identifier</th>
-                <td><tt>Permission 1</tt></td>
-              </tr>
-              <tr>
-                <th>Included in</th>
-                <td>
-                  <xref target='A1'>
-                    Requirements class 1:
-                    <tt>/ogc/recommendation/wfs/2</tt>
-                  </xref>
-                </td>
-              </tr>
-            </tbody>
+          <table id="A5" type="recommend" class="modspec">
+             <thead>
+                <tr>
+                   <th scope="colgroup" colspan="2">
+                      <p class="RecommendationTitle">
+                         <span class="fmt-caption-label">
+                            <span class="fmt-element-name">Permission</span>
+                            <semx element="autonum" source="A5">1</semx>
+                         </span>
+                      </p>
+                   </th>
+                </tr>
+             </thead>
+             <tbody>
+                <tr>
+                   <th>Identifier</th>
+                   <td>
+                      <tt>Permission 1</tt>
+                   </td>
+                </tr>
+                <tr>
+                   <th>Included in</th>
+                   <td>
+                      <span class="fmt-element-name">Requirements class</span>
+                      <semx element="autonum" source="A1">1</semx>
+                      :
+                      <tt>
+                         <xref style="id" target="A1">/ogc/recommendation/wfs/2</xref>
+                      </tt>
+                   </td>
+                </tr>
+             </tbody>
           </table>
-        </foreword>
+       </foreword>
     OUTPUT
 
     out = Nokogiri::XML(
@@ -957,13 +1220,23 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
         <table id='A1' class='modspec' type='recommendclass'>
           <thead>
             <tr>
               <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Recommendations class 1</p>
+                <p class="RecommendationTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Recommendations class</span>
+                     <semx element="autonum" source="A1">1</semx>
+                  </span>
+               </p>
               </th>
             </tr>
           </thead>
@@ -982,24 +1255,36 @@ RSpec.describe Metanorma::Requirements::Modspec do
               /ss/584/2015/level/2</td>
             </tr>
             <tr>
-              <th>Normative statements</th>
-              <td>
-                <xref target='A2'>
-                  Permission 1-1:
-                  <tt>Permission 1</tt>
-                </xref>
-                <br/>
-                <xref target='A3'>
-                  Permission 1-2:
-                  <tt>Requirement 1</tt>
-                </xref>
-                <br/>
-                <xref target='A4'>
-                  Recommendation 1-1:
-                  <tt>Recommendation 1</tt>
-                </xref>
-              </td>
-            </tr>
+                   <th>Normative statements</th>
+                   <td>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="A2">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A2">Permission 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Permission</span>
+                         <semx element="autonum" source="A3">1-2</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A3">Requirement 1</xref>
+                         </tt>
+                      </span>
+                      <br/>
+                      <span class="fmt-caption-label">
+                         <span class="fmt-element-name">Recommendation</span>
+                         <semx element="autonum" source="A4">1-1</semx>
+                         :
+                         <tt>
+                            <xref style="id" target="A4">Recommendation 1</xref>
+                         </tt>
+                      </span>
+                   </td>
+                </tr>
           </tbody>
         </table>
       </foreword>
@@ -1065,13 +1350,22 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </ogc-standard>
     INPUT
     presxml = <<~OUTPUT
-      <foreword id='A0' displayorder='2'>
-        <title>Preface</title>
+            <foreword id="A0" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
         <table id='A' unnumbered='true' class='modspec' type='recommend'>
           <thead>
             <tr>
               <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Requirement: A New Requirement</p>
+                <p class="RecommendationTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Requirement</span>
+                  </span>
+               </p>
               </th>
             </tr>
           </thead>
@@ -1103,8 +1397,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The measurement target shall be measured as:</p>
-                <formula id='B'>
-                  <name>(1)</name>
+                  <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formula</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
                   <stem type='AsciiMath'>r/1 = 0</stem>
                 </formula>
               </td>
@@ -1112,7 +1418,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The following code will be run for verification:</p>
-                <sourcecode id='_'>
+                <sourcecode id='_' autonum="2">
                   CoreRoot(success): HttpResponse if (success)
                   recommendation(label: success-response) end
                 </sourcecode>
@@ -1163,7 +1469,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
         </description>
         <measurement-target exclude="false">
           <p id="_">The measurement target shall be measured as:</p>
-          <formula id="_">
+          <formula id="B">
             <stem type="AsciiMath">r/1 = 0</stem>
           </formula>
         </measurement-target>
@@ -1184,13 +1490,23 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
         <table id='_' class='modspec' type='recommend'>
           <thead>
             <tr>
               <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Recommendation 1</p>
+                            <p class="RecommendationTitle">
+                 <span class="fmt-caption-label">
+                    <span class="fmt-element-name">Recommendation</span>
+                    <semx element="autonum" source="_">1</semx>
+                 </span>
+              </p>
               </th>
             </tr>
           </thead>
@@ -1221,8 +1537,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The measurement target shall be measured as:</p>
-                <formula id='_'>
-                  <name>(1)</name>
+                              <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formula</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
                   <stem type='AsciiMath'>r/1 = 0</stem>
                 </formula>
               </td>
@@ -1230,7 +1558,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The following code will be run for verification:</p>
-                <sourcecode id='_'>
+                <sourcecode id='_' autonum="1">
                   CoreRoot(success): HttpResponse if (success)
                   recommendation(label: success-response) end
                 </sourcecode>
@@ -1249,13 +1577,23 @@ RSpec.describe Metanorma::Requirements::Modspec do
       .to be_equivalent_to Xml::C14n.format(presxml)
 
     presxml = <<~OUTPUT
-      <foreword id="A" displayorder="2">
-         <title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
          <table id="_" class="modspec" type="recommend">
             <thead>
                <tr>
                   <th scope="colgroup" colspan="2">
-                     <p class="RecommendationTitle">Recommandation 1</p>
+                  <p class="RecommendationTitle">
+                 <span class="fmt-caption-label">
+                    <span class="fmt-element-name">Recommandation</span>
+                    <semx element="autonum" source="_">1</semx>
+                 </span>
+              </p>
                   </th>
                </tr>
             </thead>
@@ -1289,8 +1627,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
                <tr>
                   <td colspan="2">
                      <p id="_">The measurement target shall be measured as:</p>
-                     <formula id="_">
-                        <name>(1)</name>
+                                   <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formule</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
                         <stem type="AsciiMath">r/1 = 0</stem>
                      </formula>
                   </td>
@@ -1298,7 +1648,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
                <tr>
                   <td colspan="2">
                      <p id="_">The following code will be run for verification:</p>
-                     <sourcecode id="_">CoreRoot(success): HttpResponse
+                     <sourcecode id="_" autonum="1">CoreRoot(success): HttpResponse
             if (success)
             recommendation(label: success-response)
             end
@@ -1318,13 +1668,23 @@ RSpec.describe Metanorma::Requirements::Modspec do
       .to be_equivalent_to Xml::C14n.format(presxml)
 
     presxml = <<~OUTPUT
-      <foreword id='A' displayorder='2'>
-        <title>Preface</title>
+            <foreword id="A" displayorder="2">
+           <title id="_">Preface</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Preface</semx>
+              </span>
+           </fmt-title>
         <table id='_' class='modspec' type='recommend'>
           <thead>
             <tr>
               <th scope='colgroup' colspan='2'>
-                <p class='RecommendationTitle'>Provision 1</p>
+                <p class="RecommendationTitle">
+                  <span class="fmt-caption-label">
+                     <span class="fmt-element-name">Provision</span>
+                     <semx element="autonum" source="_">1</semx>
+                  </span>
+               </p>
               </th>
             </tr>
           </thead>
@@ -1355,8 +1715,20 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The measurement target shall be measured as:</p>
-                <formula id='_'>
-                  <name>(1)</name>
+                              <formula id="B" autonum="1">
+                 <fmt-name>
+                    <span class="fmt-caption-label">
+                       <span class="fmt-autonum-delim">(</span>
+                       1
+                       <span class="fmt-autonum-delim">)</span>
+                    </span>
+                 </fmt-name>
+                 <fmt-xref-label>
+                    <span class="fmt-element-name">Formula</span>
+                    <span class="fmt-autonum-delim">(</span>
+                    <semx element="autonum" source="B">1</semx>
+                    <span class="fmt-autonum-delim">)</span>
+                 </fmt-xref-label>
                   <stem type='AsciiMath'>r/1 = 0</stem>
                 </formula>
               </td>
@@ -1364,7 +1736,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
             <tr>
               <td colspan='2'>
                 <p id='_'>The following code will be run for verification:</p>
-                <sourcecode id='_'>
+                <sourcecode id='_' autonum="1">
                   CoreRoot(success): HttpResponse if (success)
                   recommendation(label: success-response) end
                 </sourcecode>

--- a/spec/modspec/xref_spec.rb
+++ b/spec/modspec/xref_spec.rb
@@ -76,34 +76,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -211,7 +211,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N1">1</semx>
                 :
@@ -219,7 +219,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N2">(??)</semx>
                 :
@@ -228,7 +228,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N">2</semx>
                 :
@@ -237,7 +237,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note1">3</semx>
                 :
@@ -246,7 +246,7 @@ RSpec.describe Metanorma::Requirements::Modspec do
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note2">4</semx>
                 :
@@ -516,67 +516,67 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1a">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N1a">1 A</semx>
              </xref>
              <xref target="N1b">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N1b">1 B</semx>
              </xref>
              <xref target="N2a">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N2a"> A</semx>
              </xref>
              <xref target="N2b">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="N2b"> B</semx>
              </xref>
              <xref target="Na">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="Na">2 A</semx>
              </xref>
              <xref target="Nb">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="Nb">2 B</semx>
              </xref>
              <xref target="note1a">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note1a">3 A</semx>
              </xref>
              <xref target="note1b">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note1b">3 B</semx>
              </xref>
              <xref target="note2a">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note2a">4 A</semx>
              </xref>
              <xref target="note2b">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Requirement</span>
                 <semx element="autonum" source="note2b">4 B</semx>
              </xref>
@@ -688,34 +688,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -816,34 +816,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Test de conformité</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Test de conformité</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Test de conformité</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Test de conformité</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Article</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Test de conformité</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -943,34 +943,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Recommendation</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -1070,34 +1070,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Conformance test</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -1197,34 +1197,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
           <p>
              <xref target="N1">
                 <semx element="introduction" source="intro">Introduction</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N1">1</semx>
              </xref>
              <xref target="N2">
                 <semx element="clause" source="xyz">Preparatory</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N2">(??)</semx>
              </xref>
              <xref target="N">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="scope">1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="N">2</semx>
              </xref>
              <xref target="note1">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="note1">3</semx>
              </xref>
              <xref target="note2">
                 <span class="fmt-element-name">Clause</span>
                 <semx element="autonum" source="widgets1">3.1</semx>
-                ,
+                <span class="fmt-comma">,</span>
                 <span class="fmt-element-name">Permission</span>
                 <semx element="autonum" source="note2">4</semx>
              </xref>
@@ -1324,34 +1324,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
            <p>
               <xref target="N1">
                  <semx element="introduction" source="intro">Introduction</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="N1">1</semx>
               </xref>
               <xref target="N2">
                  <semx element="clause" source="xyz">Preparatory</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="N2">(??)</semx>
               </xref>
               <xref target="N">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="scope">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="N">2</semx>
               </xref>
               <xref target="note1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="note1">3</semx>
               </xref>
               <xref target="note2">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="note2">4</semx>
               </xref>
@@ -1439,35 +1439,35 @@ RSpec.describe Metanorma::Requirements::Modspec do
               <xref target="N1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="xyz">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Permission</span>
                  <semx element="autonum" source="N1">1</semx>
               </xref>
               <xref target="N2">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="xyz">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance test</span>
                  <semx element="autonum" source="N2">1-1</semx>
               </xref>
               <xref target="N">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="xyz">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Permission</span>
                  <semx element="autonum" source="N">1-1-1</semx>
               </xref>
               <xref target="Q1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="xyz">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Requirement</span>
                  <semx element="autonum" source="Q1">1-1</semx>
               </xref>
               <xref target="R1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="xyz">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Recommendation</span>
                  <semx element="autonum" source="R1">1-1</semx>
               </xref>
@@ -1575,34 +1575,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
            <p>
               <xref target="N1">
                  <semx element="introduction" source="intro">Introduction</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Abstract test</span>
                  <semx element="autonum" source="N1">1</semx>
               </xref>
               <xref target="N2">
                  <semx element="clause" source="xyz">Preparatory</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Abstract test</span>
                  <semx element="autonum" source="N2">(??)</semx>
               </xref>
               <xref target="N">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="scope">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Abstract test</span>
                  <semx element="autonum" source="N">2</semx>
               </xref>
               <xref target="note1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Abstract test</span>
                  <semx element="autonum" source="note1">3</semx>
               </xref>
               <xref target="note2">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Abstract test</span>
                  <semx element="autonum" source="note2">4</semx>
               </xref>
@@ -1703,34 +1703,34 @@ RSpec.describe Metanorma::Requirements::Modspec do
            <p>
               <xref target="N1">
                  <semx element="introduction" source="intro">Introduction</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance class</span>
                  <semx element="autonum" source="N1">1</semx>
               </xref>
               <xref target="N2">
                  <semx element="clause" source="xyz">Preparatory</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance class</span>
                  <semx element="autonum" source="N2">(??)</semx>
               </xref>
               <xref target="N">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="scope">1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance class</span>
                  <semx element="autonum" source="N">2</semx>
               </xref>
               <xref target="note1">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance class</span>
                  <semx element="autonum" source="note1">3</semx>
               </xref>
               <xref target="note2">
                  <span class="fmt-element-name">Clause</span>
                  <semx element="autonum" source="widgets1">3.1</semx>
-                 ,
+                 <span class="fmt-comma">,</span>
                  <span class="fmt-element-name">Conformance class</span>
                  <semx element="autonum" source="note2">4</semx>
               </xref>

--- a/spec/modspec/xref_spec.rb
+++ b/spec/modspec/xref_spec.rb
@@ -67,22 +67,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Requirement 1</xref>
-          <xref target='N2'>Preparatory, Requirement (??)</xref>
-          <xref target='N'>Clause 1, Requirement 2</xref>
-          <xref target='note1'>Clause 3.1, Requirement 3</xref>
-          <xref target='note2'>Clause 3.1, Requirement 4</xref>
-          <xref target='AN'>Requirement A.1</xref>
-          <xref target='Anote1'>Requirement (??)</xref>
-          <xref target='Anote2'>Requirement A.2</xref>
-        </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -160,46 +202,80 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-              <p>
-                   <xref target='N1'>
-           Introduction, Requirement 1:
-           <tt>/ogc/req1</tt>
-         </xref>
-         <xref target='N2'>
-           Preparatory, Requirement (??):
-           <tt>/ogc/req2</tt>
-         </xref>
-         <xref target='N'>
-           Clause 1, Requirement 2:
-           <tt>/ogc/req3</tt>
-         </xref>
-         <xref target='note1'>
-           Clause 3.1, Requirement 3:
-           <tt>/ogc/req4</tt>
-         </xref>
-         <xref target='note2'>
-           Clause 3.1, Requirement 4:
-           <tt>/ogc/req5</tt>
-         </xref>
-         <xref target='AN'>
-           Requirement A.1:
-           <tt>/ogc/req6</tt>
-         </xref>
-         <xref target='Anote1'>
-           Requirement (??):
-           <tt>/ogc/req7</tt>
-         </xref>
-         <xref target='Anote2'>
-           Requirement A.2:
-           <tt>/ogc/req8</tt>
-         </xref>
-              </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1">1</semx>
+                :
+                <tt>/ogc/req1</tt>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2">(??)</semx>
+                :
+                <tt>/ogc/req2</tt>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N">2</semx>
+                :
+                <tt>/ogc/req3</tt>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1">3</semx>
+                :
+                <tt>/ogc/req4</tt>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2">4</semx>
+                :
+                <tt>/ogc/req5</tt>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="AN">A.1</semx>
+                :
+                <tt>/ogc/req6</tt>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+                :
+                <tt>/ogc/req7</tt>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+                :
+                <tt>/ogc/req8</tt>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -277,46 +353,67 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-              <p>
-                   <xref target='N1' style="modspec">
-           Requirement 1:
-           <tt>/ogc/req1</tt>
-         </xref>
-         <xref target='N2' style="modspec">
-           Requirement (??):
-           <tt>/ogc/req2</tt>
-         </xref>
-         <xref target='N' style="modspec">
-           Requirement 2:
-           <tt>/ogc/req3</tt>
-         </xref>
-         <xref target='note1' style="modspec">
-           Requirement 3:
-           <tt>/ogc/req4</tt>
-         </xref>
-         <xref target='note2' style="modspec">
-           Requirement 4:
-           <tt>/ogc/req5</tt>
-         </xref>
-         <xref target='AN' style="modspec">
-           Requirement A.1:
-           <tt>/ogc/req6</tt>
-         </xref>
-         <xref target='Anote1' style="modspec">
-           Requirement (??):
-           <tt>/ogc/req7</tt>
-         </xref>
-         <xref target='Anote2' style="modspec">
-           Requirement A.2:
-           <tt>/ogc/req8</tt>
-         </xref>
-              </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1">1</semx>
+                :
+                <tt>/ogc/req1</tt>
+             </xref>
+             <xref target="N2" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2">(??)</semx>
+                :
+                <tt>/ogc/req2</tt>
+             </xref>
+             <xref target="N" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N">2</semx>
+                :
+                <tt>/ogc/req3</tt>
+             </xref>
+             <xref target="note1" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1">3</semx>
+                :
+                <tt>/ogc/req4</tt>
+             </xref>
+             <xref target="note2" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2">4</semx>
+                :
+                <tt>/ogc/req5</tt>
+             </xref>
+             <xref target="AN" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="AN">A.1</semx>
+                :
+                <tt>/ogc/req6</tt>
+             </xref>
+             <xref target="Anote1" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+                :
+                <tt>/ogc/req7</tt>
+             </xref>
+             <xref target="Anote2" style="modspec">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+                :
+                <tt>/ogc/req8</tt>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -409,31 +506,110 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-      <foreword displayorder='2'>
-      <title>Foreword</title>
-        <p>
-          <xref target='N1a'>Introduction, Requirement 1 A</xref>
-          <xref target='N1b'>Introduction, Requirement 1 B</xref>
-          <xref target='N2a'>Preparatory, Requirement A</xref>
-          <xref target='N2b'>Preparatory, Requirement B</xref>
-          <xref target='Na'>Clause 1, Requirement 2 A</xref>
-          <xref target='Nb'>Clause 1, Requirement 2 B</xref>
-          <xref target='note1a'>Clause 3.1, Requirement 3 A</xref>
-          <xref target='note1b'>Clause 3.1, Requirement 3 B</xref>
-          <xref target='note2a'>Clause 3.1, Requirement 4 A</xref>
-          <xref target='note2b'>Clause 3.1, Requirement 4 B</xref>
-          <xref target='ANa'>Requirement A.1 A</xref>
-          <xref target='ANb'>Requirement A.1 B</xref>
-          <xref target='Anote1a'>Requirement A. A</xref>
-          <xref target='Anote1b'>Requirement A. B</xref>
-          <xref target='Anote2a'>Requirement A.2 A</xref>
-          <xref target='Anote2b'>Requirement A.2 B</xref>
-        </p>
-      </foreword>
+      <foreword displayorder="2">
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1a">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1a">1 A</semx>
+             </xref>
+             <xref target="N1b">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N1b">1 B</semx>
+             </xref>
+             <xref target="N2a">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2a"> A</semx>
+             </xref>
+             <xref target="N2b">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="N2b"> B</semx>
+             </xref>
+             <xref target="Na">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Na">2 A</semx>
+             </xref>
+             <xref target="Nb">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Nb">2 B</semx>
+             </xref>
+             <xref target="note1a">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1a">3 A</semx>
+             </xref>
+             <xref target="note1b">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note1b">3 B</semx>
+             </xref>
+             <xref target="note2a">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2a">4 A</semx>
+             </xref>
+             <xref target="note2b">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="note2b">4 B</semx>
+             </xref>
+             <xref target="ANa">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="ANa">A.1 A</semx>
+             </xref>
+             <xref target="ANb">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="ANb">A.1 B</semx>
+             </xref>
+             <xref target="Anote1a">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1a">A. A</semx>
+             </xref>
+             <xref target="Anote1b">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote1b">A. B</semx>
+             </xref>
+             <xref target="Anote2a">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2a">A.2 A</semx>
+             </xref>
+             <xref target="Anote2b">
+                <span class="fmt-element-name">Requirement</span>
+                <semx element="autonum" source="Anote2b">A.2 B</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -503,22 +679,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Conformance test 1</xref>
-          <xref target='N2'>Preparatory, Conformance test (??)</xref>
-          <xref target='N'>Clause 1, Conformance test 2</xref>
-          <xref target='note1'>Clause 3.1, Conformance test 3</xref>
-          <xref target='note2'>Clause 3.1, Conformance test 4</xref>
-          <xref target='AN'>Conformance test A.1</xref>
-          <xref target='Anote1'>Conformance test (??)</xref>
-          <xref target='Anote2'>Conformance test A.2</xref>
-        </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -588,23 +806,65 @@ RSpec.describe Metanorma::Requirements::Modspec do
           </iso-standard>
     INPUT
     output = <<~OUTPUT
-      <foreword displayorder='2'>
-      <title>Avant-propos</title>
-         <p>
-           <xref target='N1'>Introduction, Test de conformit&#xE9; 1</xref>
-           <xref target='N2'>Preparatory, Test de conformit&#xE9; (??)</xref>
-           <xref target='N'>Article 1, Test de conformit&#xE9; 2</xref>
-           <xref target='note1'>Article 3.1, Test de conformit&#xE9; 3</xref>
-           <xref target='note2'>Article 3.1, Test de conformit&#xE9; 4</xref>
-           <xref target='AN'>Test de conformit&#xE9; A.1</xref>
-           <xref target='Anote1'>Test de conformit&#xE9; (??)</xref>
-           <xref target='Anote2'>Test de conformit&#xE9; A.2</xref>
-         </p>
+      <foreword displayorder="2">
+          <title id="_">Avant-propos</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Avant-propos</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Article</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Test de conformité</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
        </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -674,22 +934,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Recommendation 1</xref>
-          <xref target='N2'>Preparatory, Recommendation (??)</xref>
-          <xref target='N'>Clause 1, Recommendation 2</xref>
-          <xref target='note1'>Clause 3.1, Recommendation 3</xref>
-          <xref target='note2'>Clause 3.1, Recommendation 4</xref>
-          <xref target='AN'>Recommendation A.1</xref>
-          <xref target='Anote1'>Recommendation (??)</xref>
-          <xref target='Anote2'>Recommendation A.2</xref>
-        </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Recommendation</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -759,22 +1061,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Conformance test 1</xref>
-          <xref target='N2'>Preparatory, Conformance test (??)</xref>
-          <xref target='N'>Clause 1, Conformance test 2</xref>
-          <xref target='note1'>Clause 3.1, Conformance test 3</xref>
-          <xref target='note2'>Clause 3.1, Conformance test 4</xref>
-          <xref target='AN'>Conformance test A.1</xref>
-          <xref target='Anote1'>Conformance test (??)</xref>
-          <xref target='Anote2'>Conformance test A.2</xref>
-        </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Conformance test</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -844,22 +1188,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Permission 1</xref>
-          <xref target='N2'>Preparatory, Permission (??)</xref>
-          <xref target='N'>Clause 1, Permission 2</xref>
-          <xref target='note1'>Clause 3.1, Permission 3</xref>
-          <xref target='note2'>Clause 3.1, Permission 4</xref>
-          <xref target='AN'>Permission A.1</xref>
-          <xref target='Anote1'>Permission (??)</xref>
-          <xref target='Anote2'>Permission A.2</xref>
-        </p>
-      </foreword>
+          <title id="_">Foreword</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="title" id="_">Foreword</semx>
+             </span>
+          </fmt-title>
+          <p>
+             <xref target="N1">
+                <semx element="introduction" source="intro">Introduction</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N1">1</semx>
+             </xref>
+             <xref target="N2">
+                <semx element="clause" source="xyz">Preparatory</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N2">(??)</semx>
+             </xref>
+             <xref target="N">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="scope">1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="N">2</semx>
+             </xref>
+             <xref target="note1">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="note1">3</semx>
+             </xref>
+             <xref target="note2">
+                <span class="fmt-element-name">Clause</span>
+                <semx element="autonum" source="widgets1">3.1</semx>
+                ,
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="note2">4</semx>
+             </xref>
+             <xref target="AN">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="AN">A.1</semx>
+             </xref>
+             <xref target="Anote1">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="Anote1">(??)</semx>
+             </xref>
+             <xref target="Anote2">
+                <span class="fmt-element-name">Permission</span>
+                <semx element="autonum" source="Anote2">A.2</semx>
+             </xref>
+          </p>
+       </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -929,22 +1315,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Conformance test 1</xref>
-          <xref target='N2'>Preparatory, Conformance test (??)</xref>
-          <xref target='N'>Clause 1, Conformance test 2</xref>
-          <xref target='note1'>Clause 3.1, Conformance test 3</xref>
-          <xref target='note2'>Clause 3.1, Conformance test 4</xref>
-          <xref target='AN'>Conformance test A.1</xref>
-          <xref target='Anote1'>Conformance test (??)</xref>
-          <xref target='Anote2'>Conformance test A.2</xref>
-        </p>
-      </foreword>
+           <title id="_">Foreword</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Foreword</semx>
+              </span>
+           </fmt-title>
+           <p>
+              <xref target="N1">
+                 <semx element="introduction" source="intro">Introduction</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="N1">1</semx>
+              </xref>
+              <xref target="N2">
+                 <semx element="clause" source="xyz">Preparatory</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="N2">(??)</semx>
+              </xref>
+              <xref target="N">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="scope">1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="N">2</semx>
+              </xref>
+              <xref target="note1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="note1">3</semx>
+              </xref>
+              <xref target="note2">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="note2">4</semx>
+              </xref>
+              <xref target="AN">
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="AN">A.1</semx>
+              </xref>
+              <xref target="Anote1">
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="Anote1">(??)</semx>
+              </xref>
+              <xref target="Anote2">
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="Anote2">A.2</semx>
+              </xref>
+           </p>
+        </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -1001,24 +1429,74 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-      <p>
-          <xref target='N1'>Clause 1, Permission 1</xref>
-          <xref target='N2'>Clause 1, Conformance test 1-1</xref>
-          <xref target='N'>Clause 1, Permission 1-1-1</xref>
-          <xref target='Q1'>Clause 1, Requirement 1-1</xref>
-          <xref target='R1'>Clause 1, Recommendation 1-1</xref>
-          <xref target='AN1'>Conformance test A.1</xref>
-          <xref target='AN2'>Permission A.1-1</xref>
-          <xref target='AN'>Conformance test A.1-1-1</xref>
-          <xref target='AQ1'>Requirement A.1-1</xref>
-          <xref target='AR1'>Recommendation A.1-1</xref>
-        </p>
-      </foreword>
+           <title id="_">Foreword</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Foreword</semx>
+              </span>
+           </fmt-title>
+           <p>
+              <xref target="N1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="xyz">1</semx>
+                 ,
+                 <span class="fmt-element-name">Permission</span>
+                 <semx element="autonum" source="N1">1</semx>
+              </xref>
+              <xref target="N2">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="xyz">1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="N2">1-1</semx>
+              </xref>
+              <xref target="N">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="xyz">1</semx>
+                 ,
+                 <span class="fmt-element-name">Permission</span>
+                 <semx element="autonum" source="N">1-1-1</semx>
+              </xref>
+              <xref target="Q1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="xyz">1</semx>
+                 ,
+                 <span class="fmt-element-name">Requirement</span>
+                 <semx element="autonum" source="Q1">1-1</semx>
+              </xref>
+              <xref target="R1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="xyz">1</semx>
+                 ,
+                 <span class="fmt-element-name">Recommendation</span>
+                 <semx element="autonum" source="R1">1-1</semx>
+              </xref>
+              <xref target="AN1">
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="AN1">A.1</semx>
+              </xref>
+              <xref target="AN2">
+                 <span class="fmt-element-name">Permission</span>
+                 <semx element="autonum" source="AN2">A.1-1</semx>
+              </xref>
+              <xref target="AN">
+                 <span class="fmt-element-name">Conformance test</span>
+                 <semx element="autonum" source="AN">A.1-1-1</semx>
+              </xref>
+              <xref target="AQ1">
+                 <span class="fmt-element-name">Requirement</span>
+                 <semx element="autonum" source="AQ1">A.1-1</semx>
+              </xref>
+              <xref target="AR1">
+                 <span class="fmt-element-name">Recommendation</span>
+                 <semx element="autonum" source="AR1">A.1-1</semx>
+              </xref>
+           </p>
+        </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -1088,22 +1566,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Abstract test 1</xref>
-          <xref target='N2'>Preparatory, Abstract test (??)</xref>
-          <xref target='N'>Clause 1, Abstract test 2</xref>
-          <xref target='note1'>Clause 3.1, Abstract test 3</xref>
-          <xref target='note2'>Clause 3.1, Abstract test 4</xref>
-          <xref target='AN'>Abstract test A.1</xref>
-          <xref target='Anote1'>Abstract test (??)</xref>
-          <xref target='Anote2'>Abstract test A.2</xref>
-        </p>
-      </foreword>
+           <title id="_">Foreword</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Foreword</semx>
+              </span>
+           </fmt-title>
+           <p>
+              <xref target="N1">
+                 <semx element="introduction" source="intro">Introduction</semx>
+                 ,
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="N1">1</semx>
+              </xref>
+              <xref target="N2">
+                 <semx element="clause" source="xyz">Preparatory</semx>
+                 ,
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="N2">(??)</semx>
+              </xref>
+              <xref target="N">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="scope">1</semx>
+                 ,
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="N">2</semx>
+              </xref>
+              <xref target="note1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="note1">3</semx>
+              </xref>
+              <xref target="note2">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="note2">4</semx>
+              </xref>
+              <xref target="AN">
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="AN">A.1</semx>
+              </xref>
+              <xref target="Anote1">
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="Anote1">(??)</semx>
+              </xref>
+              <xref target="Anote2">
+                 <span class="fmt-element-name">Abstract test</span>
+                 <semx element="autonum" source="Anote2">A.2</semx>
+              </xref>
+           </p>
+        </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 
@@ -1174,22 +1694,64 @@ RSpec.describe Metanorma::Requirements::Modspec do
     INPUT
     output = <<~OUTPUT
       <foreword displayorder="2">
-      <title>Foreword</title>
-        <p>
-          <xref target='N1'>Introduction, Conformance class 1</xref>
-          <xref target='N2'>Preparatory, Conformance class (??)</xref>
-          <xref target='N'>Clause 1, Conformance class 2</xref>
-          <xref target='note1'>Clause 3.1, Conformance class 3</xref>
-          <xref target='note2'>Clause 3.1, Conformance class 4</xref>
-          <xref target='AN'>Conformance class A.1</xref>
-          <xref target='Anote1'>Conformance class (??)</xref>
-          <xref target='Anote2'>Conformance class A.2</xref>
-        </p>
-      </foreword>
+           <title id="_">Foreword</title>
+           <fmt-title depth="1">
+              <span class="fmt-caption-label">
+                 <semx element="title" id="_">Foreword</semx>
+              </span>
+           </fmt-title>
+           <p>
+              <xref target="N1">
+                 <semx element="introduction" source="intro">Introduction</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="N1">1</semx>
+              </xref>
+              <xref target="N2">
+                 <semx element="clause" source="xyz">Preparatory</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="N2">(??)</semx>
+              </xref>
+              <xref target="N">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="scope">1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="N">2</semx>
+              </xref>
+              <xref target="note1">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="note1">3</semx>
+              </xref>
+              <xref target="note2">
+                 <span class="fmt-element-name">Clause</span>
+                 <semx element="autonum" source="widgets1">3.1</semx>
+                 ,
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="note2">4</semx>
+              </xref>
+              <xref target="AN">
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="AN">A.1</semx>
+              </xref>
+              <xref target="Anote1">
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="Anote1">(??)</semx>
+              </xref>
+              <xref target="Anote2">
+                 <span class="fmt-element-name">Conformance class</span>
+                 <semx element="autonum" source="Anote2">A.2</semx>
+              </xref>
+           </p>
+        </foreword>
     OUTPUT
-    expect(Xml::C14n.format(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
+    expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::PresentationXMLConvert.new({})
       .convert("test", input, true))
-      .at("//xmlns:foreword").to_xml))
+      .at("//xmlns:foreword").to_xml)))
       .to be_equivalent_to Xml::C14n.format(output)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,7 @@ HDR
 
 def strip_guid(xml)
   xml.gsub(%r{ id="_[^"]+"}, ' id="_"')
+    .gsub(%r{ source="_[^"]+"}, ' id="_"')
     .gsub(%r{ target="_[^"]+"}, ' target="_"')
     .gsub(%r{ schema-version=['"][^'"]+['"]}, "")
     .gsub(%r{<fetched>[^<]+</fetched>}, "<fetched/>")


### PR DESCRIPTION
…dspec identifier component of modspec label in modspec table rows:    https://github.com/metanorma/isodoc/issues/617

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
