### PR TITLE
drop load-time require of isodoc: circular, undeclared

### DIFF
--- a/lib/metanorma/default/isodoc.rb
+++ b/lib/metanorma/default/isodoc.rb
@@ -1,4 +1,3 @@
-require "isodoc"
 
 module Metanorma
   class Requirements


### PR DESCRIPTION
Closes https://github.com/metanorma/mn-requirements/issues/53

Root-cause narrative in the ticket. One deletion: metanorma/default/isodoc.rb no longer requires isodoc at load; the host injects itself.

🤖
